### PR TITLE
adding a repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
     "name": "khan-linter",
     "version": "0.0.1",
+    "repository": {
+      "type" : "git",
+      "url" : "https://github.com/Khan/khan-linter.git"
+    },
     "dependencies": {
         "jshint": "2.1.10",
         "react-tools": "0.4.1"


### PR DESCRIPTION
Npm is silly and warns when you don't have a repository field.

```
 npm WARN package.json khan-linter@0.0.1 No repository field.
```

And it does confuses users https://github.com/npm/npm/issues/3568 .
