### PR TITLE
Updating PEP8 1.5.6 from 1.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required by python lint checking
-pep8==1.0.1
+pep8==1.5.6
 pyflakes==0.7.3
 
 # Required by js lint checking

--- a/runlint.py
+++ b/runlint.py
@@ -108,7 +108,7 @@ def _capture_stdout_of(fn, *args, **kwargs):
 class Pep8(Linter):
     """Linter for python.  process() processes one file."""
     def __init__(self, pep8_args):
-        pep8.process_options(pep8_args + ['dummy'])
+        self.options = pep8.StyleGuide({'paths': pep8_args}).options
 
     def _munge_output_line(self, line):
         """Modify the line to have the canonical form for lint lines."""
@@ -188,8 +188,9 @@ class Pep8(Linter):
     def process(self, f, contents_of_f):
         contents_lines = contents_of_f.splitlines(True)
 
+        checker = pep8.Checker(f, lines=contents_lines, options=self.options)
         (num_candidate_errors, pep8_stdout) = _capture_stdout_of(
-            pep8.Checker(f, lines=contents_lines).check_all)
+            checker.check_all)
 
         # Go through the output and remove the 'actually ok' lines.
         if num_candidate_errors == 0:


### PR DESCRIPTION
The one obvious blocking change is that PEP8 changed how they process options
in version 1.3 around a StyleGuide object. This changed the internal api which
Khan Linter uses.

See:
https://github.com/jcrocholl/pep8/blob/96290d48b1334fe8542666174d7775cda3f46d9a/CHANGES.txt#L343

Currently, if you accidentally use PEP 1.3+ with Khan Linter, you'll get your
results, but _DEFAULT_PEP8_ARGS will be ignored.

Reading through the rest of the changelog and quick informal tests imply that
this is the only internal api change and upgrading is otherwise safe.
(Famous last words...)

Just for reference:
1.0.1 was released 2012-04-06
1.5.6 was released 2014-04-14