### PR TITLE
fix an issue when linting .jsx files

### DIFF
--- a/README
+++ b/README
@@ -20,6 +20,9 @@ Usage
 First, install dependent packages via the requirements.txt file
    $ pip install -r requirements.txt
 
+Then install node.js dependencies
+   $ npm install
+
 Then you can automatically invoke lints on modified or added files in
 Mercurial.  Add to .hgrc to use:
 

--- a/runlint.py
+++ b/runlint.py
@@ -557,6 +557,8 @@ class JsxLinter(Linter):
         num_errors = 0
         # need these for filtering
         contents_lines = transformed_source.splitlines()
+        # guard against errors on the last line
+        contents_lines.append("");
         for output_line in stdout.splitlines():
             num_errors += self._process_one_line(f, output_line,
                                                  contents_lines)


### PR DESCRIPTION
Prevented a list out of range error when linting .jsx files that report lint on the last line where the last line is empty.  Updated README.md to include step to install node.js dependencies.