### PR TITLE
fix hardcoded path in .arclint

### DIFF
--- a/.arclint
+++ b/.arclint
@@ -2,7 +2,7 @@
   "linters": {
     "khan-linter": {
       "type": "script-and-regex",
-      "script-and-regex.script": "~\/khan\/devtools\/khan-linter\/runlint.py --always-exit-0 --blacklist=yes --propose-arc-fixes",
+      "script-and-regex.script": "ka-lint --always-exit-0 --blacklist=yes --propose-arc-fixes",
       "script-and-regex.regex": "\/^((?P<file>[^:]*):(?P<line>\\d+):((?P<char>\\d+):)? (?P<name>((?P<error>E)|(?P<warning>W))\\S+) (?P<message>[^\\x00\n]*)(\\x00(?P<original>[^\\x00]*)\\x00(?P<replacement>[^\\x00]*)\\x00)?)|(?P<ignore>SKIPPING.*)$\/m"
     }
   }


### PR DESCRIPTION
A long while ago we migrated to preferring using `$PATH` and not assuming hardcoded tool locations on the system.  Looks like we missed that in this repository.

(Kinda ironic, since this is the repo for the linter itself)

Test plan: run `arc lint`