### PR TITLE
initial proof-of-concept in a container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+vendor
+.git
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:2.7-alpine
+MAINTAINER mroth@khanacademy.org
+WORKDIR /app
+
+# add LTS version of nodejs
+RUN apk --no-cache add nodejs
+
+# install nodejs packages
+COPY package.json .
+RUN npm install
+
+# install python packages
+COPY requirements.txt .
+RUN pip2 install --no-cache-dir --target=vendor/py2 -r requirements.txt
+
+COPY . .
+CMD [ "/app/runlint.py", "/src", "-v" ]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+image:
+	docker build -t khanacademy/khan-linter .
+
+deploy: image
+	docker push khanacademy/khan-linter
+
 deps vendor_deps: check_setup
 	rm -r vendor/py2/* || true
 	rm -r vendor/py3/* || true
@@ -7,8 +13,6 @@ deps vendor_deps: check_setup
 	npm update
 	npm prune
 	echo "DONE.  Consider running:  git add -A vendor node_modules"
-
-
 
 check_setup:
 	@command -v npm > /dev/null || echo "missing dependencies: need to install npm"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ you can specify files on the command line to lint.  See
 
 for more options.
 
+via Docker image
+----------------
+A built image with all pre-requesites is available on Docker Hub as `khanacademy/khan-linter`.
+
+Mount the directory you wish to lint as a volume (by default, the image CMD is configured to look in `/src` if nothing else is specified).
+
+For example, to lint the current directory:
+
+    docker run -it --rm -v $(pwd):/src khanacademy/khan-linter
+
+If the image is not already on the local environment, it will automatically be downloaded prior to execution.
+
 Automatic
 ---------
 You can update the blacklist file in this repository to control what files


### PR DESCRIPTION
This is a potential alternate way to look at distribution of a dev tool with dependencies using Docker, versus the current vendoring/packaging methodology.

Instead of trying to vendor/bundle all the python/node dependency files in a way that will work on most systems, just build a self-contained docker image. This frees us from having to worry at all about if/what versions of Python/NodeJS are on the machine.

When the linter is updated, new images would be uploaded to Docker Hub (using that vs a private GCR since this is an open source project), end-users can `docker pull khanacademy/khan-linter:latest` (or a specific version/tag)

This also would provide an alternate way to run on a server without worrying conflicting dependencies between this and the app it is linting.

Note I haven't actually pushed the built image to Docker Hub yet, will do so if/after this is merged.

Future enhancements
-------------------
For convenience of tagging docker images, it would be good to be more consistent with updating semantic version of releases, and then have the `make image` task here add the version number, to the image tag, so people could more easily reason about what version they have on their system, especially when doing a `docker images` list or some such.

What would it mean to fully embrace this?
-----------------------------------------
In a mystical future world if the docker image was to become the "one true way" to use this, then there are some cleanup tasks that would probably become worth looking at:

- the py2 vs py3 branching and vendoring logic could be removed entirely.
- the update_check can be removed entirely in favor of pulling the latest docker image (it currently won't fire within the container because its not in a git repo, but the code could be removed for cleanliness then.)
- the big vendored directories can be removed from this git repo, as with the associated Make tasks.