### PR TITLE
Add eslint-plugin-jest

### DIFF
--- a/node_modules/eslint-plugin-jest/CHANGELOG.md
+++ b/node_modules/eslint-plugin-jest/CHANGELOG.md
@@ -1,0 +1,6 @@
+# [22.2.0](https://github.com/jest-community/eslint-plugin-jest/compare/v22.1.3...v22.2.0) (2019-01-29)
+
+
+### Features
+
+* **rules:** add prefer-todo rule ([#218](https://github.com/jest-community/eslint-plugin-jest/issues/218)) ([0933d82](https://github.com/jest-community/eslint-plugin-jest/commit/0933d82)), closes [#217](https://github.com/jest-community/eslint-plugin-jest/issues/217)

--- a/node_modules/eslint-plugin-jest/LICENSE
+++ b/node_modules/eslint-plugin-jest/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Jonathan Kim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/eslint-plugin-jest/README.md
+++ b/node_modules/eslint-plugin-jest/README.md
@@ -1,0 +1,164 @@
+[![Build Status](https://travis-ci.org/jest-community/eslint-plugin-jest.svg?branch=master)](https://travis-ci.org/jest-community/eslint-plugin-jest)
+[![Greenkeeper badge](https://badges.greenkeeper.io/jest-community/eslint-plugin-jest.svg)](https://greenkeeper.io/)
+
+<div align="center">
+  <a href="https://eslint.org/">
+    <img width="150" height="150" src="https://eslint.org/img/logo.svg">
+  </a>
+  <a href="https://facebook.github.io/jest/">
+    <img width="150" height="150" vspace="" hspace="25" src="https://jestjs.io/img/jest.png">
+  </a>
+  <h1>eslint-plugin-jest</h1>
+  <p>ESLint plugin for Jest</p>
+</div>
+
+## Installation
+
+```
+$ yarn add --dev eslint eslint-plugin-jest
+```
+
+**Note:** If you installed ESLint globally then you must also install
+`eslint-plugin-jest` globally.
+
+## Usage
+
+Add `jest` to the plugins section of your `.eslintrc` configuration file. You
+can omit the `eslint-plugin-` prefix:
+
+```json
+{
+  "plugins": ["jest"]
+}
+```
+
+Then configure the rules you want to use under the rules section.
+
+```json
+{
+  "rules": {
+    "jest/no-disabled-tests": "warn",
+    "jest/no-focused-tests": "error",
+    "jest/no-identical-title": "error",
+    "jest/prefer-to-have-length": "warn",
+    "jest/valid-expect": "error"
+  }
+}
+```
+
+You can also whitelist the environment variables provided by Jest by doing:
+
+```json
+{
+  "env": {
+    "jest/globals": true
+  }
+}
+```
+
+## Shareable configurations
+
+### Recommended
+
+This plugin exports a recommended configuration that enforces good testing
+practices.
+
+To enable this configuration use the `extends` property in your `.eslintrc`
+config file:
+
+```json
+{
+  "extends": ["plugin:jest/recommended"]
+}
+```
+
+### Style
+
+This plugin also exports a configuration named `style`, which adds some
+stylistic rules, such as `prefer-to-be-null`, which enforces usage of `toBeNull`
+over `toBe(null)`. All rules included are:
+
+- `prefer-to-be-null`
+- `prefer-to-be-undefined`
+- `prefer-to-contain`
+- `prefer-to-have-length`
+
+See
+[ESLint documentation](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)
+for more information about extending configuration files.
+
+## Rules
+
+| Rule                         | Description                                                       | Recommended      | Fixable             |
+| ---------------------------- | ----------------------------------------------------------------- | ---------------- | ------------------- |
+| [consistent-test-it][]       | Enforce consistent test or it keyword                             |                  | ![fixable-green][]  |
+| [expect-expect][]            | Enforce assertion to be made in a test body                       |                  |                     |
+| [lowercase-name][]           | Disallow capitalized test names                                   |                  | ![fixable-green][]  |
+| [no-alias-methods][]         | Disallow alias methods                                            | ![recommended][] | ![fixable-green][]  |
+| [no-disabled-tests][]        | Disallow disabled tests                                           | ![recommended][] |                     |
+| [no-empty-title][]           | Disallow empty titles                                             |                  |                     |
+| [no-focused-tests][]         | Disallow focused tests                                            | ![recommended][] |                     |
+| [no-hooks][]                 | Disallow setup and teardown hooks                                 |                  |                     |
+| [no-identical-title][]       | Disallow identical titles                                         | ![recommended][] |                     |
+| [no-jasmine-globals][]       | Disallow Jasmine globals                                          | ![recommended][] | ![fixable-yellow][] |
+| [no-jest-import][]           | Disallow importing `jest`                                         | ![recommended][] |                     |
+| [no-mocks-import][]          | Disallow manually importing from `__mocks__`                      |                  |                     |
+| [no-large-snapshots][]       | Disallow large snapshots                                          |                  |                     |
+| [no-test-callback][]         | Using a callback in asynchronous tests                            |                  | ![fixable-green][]  |
+| [no-test-prefixes][]         | Disallow using `f` & `x` prefixes to define focused/skipped tests | ![recommended][] | ![fixable-green][]  |
+| [no-test-return-statement][] | Disallow explicitly returning from tests                          |                  |                     |
+| [no-truthy-falsy][]          | Disallow using `toBeTruthy()` & `toBeFalsy()`                     |                  |                     |
+| [prefer-expect-assertions][] | Suggest using `expect.assertions()` OR `expect.hasAssertions()`   |                  |                     |
+| [prefer-spy-on][]            | Suggest using `jest.spyOn()`                                      |                  | ![fixable-green][]  |
+| [prefer-strict-equal][]      | Suggest using `toStrictEqual()`                                   |                  | ![fixable-green][]  |
+| [prefer-to-be-null][]        | Suggest using `toBeNull()`                                        |                  | ![fixable-green][]  |
+| [prefer-to-be-undefined][]   | Suggest using `toBeUndefined()`                                   |                  | ![fixable-green][]  |
+| [prefer-to-contain][]        | Suggest using `toContain()`                                       |                  | ![fixable-green][]  |
+| [prefer-to-have-length][]    | Suggest using `toHaveLength()`                                    |                  | ![fixable-green][]  |
+| [prefer-inline-snapshots][]  | Suggest using `toMatchInlineSnapshot()`                           |                  | ![fixable-green][]  |
+| [require-tothrow-message][]  | Require that `toThrow()` and `toThrowError` includes a message    |                  |                     |
+| [valid-describe][]           | Enforce valid `describe()` callback                               | ![recommended][] |                     |
+| [valid-expect-in-promise][]  | Enforce having return statement when testing with promises        | ![recommended][] |                     |
+| [valid-expect][]             | Enforce valid `expect()` usage                                    | ![recommended][] |                     |
+| [prefer-todo][]              | Suggest using `test.todo()`                                       |                  | ![fixable-green][]  |
+| [prefer-called-with][]       | Suggest using `toBeCalledWith()` OR `toHaveBeenCalledWith()`      |                  |                     |
+
+## Credit
+
+- [eslint-plugin-mocha](https://github.com/lo1tuma/eslint-plugin-mocha)
+- [eslint-plugin-jasmine](https://github.com/tlvince/eslint-plugin-jasmine)
+
+[consistent-test-it]: docs/rules/consistent-test-it.md
+[expect-expect]: docs/rules/expect-expect.md
+[lowercase-name]: docs/rules/lowercase-name.md
+[no-alias-methods]: docs/rules/no-alias-methods.md
+[no-disabled-tests]: docs/rules/no-disabled-tests.md
+[no-empty-title]: docs/rules/no-empty-title.md
+[no-focused-tests]: docs/rules/no-focused-tests.md
+[no-hooks]: docs/rules/no-hooks.md
+[no-identical-title]: docs/rules/no-identical-title.md
+[no-jasmine-globals]: docs/rules/no-jasmine-globals.md
+[no-jest-import]: docs/rules/no-jest-import.md
+[no-mocks-import]: docs/rules/no-mocks-import.md
+[no-large-snapshots]: docs/rules/no-large-snapshots.md
+[no-test-callback]: docs/rules/no-test-callback.md
+[no-test-prefixes]: docs/rules/no-test-prefixes.md
+[no-test-return-statement]: docs/rules/no-test-return-statement.md
+[no-truthy-falsy]: docs/rules/no-truthy-falsy.md
+[prefer-called-with]: docs/rules/prefer-called-with.md
+[prefer-expect-assertions]: docs/rules/prefer-expect-assertions.md
+[prefer-spy-on]: docs/rules/prefer-spy-on.md
+[prefer-strict-equal]: docs/rules/prefer-strict-equal.md
+[prefer-to-be-null]: docs/rules/prefer-to-be-null.md
+[prefer-to-be-undefined]: docs/rules/prefer-to-be-undefined.md
+[prefer-to-contain]: docs/rules/prefer-to-contain.md
+[prefer-to-have-length]: docs/rules/prefer-to-have-length.md
+[prefer-inline-snapshots]: docs/rules/prefer-inline-snapshots.md
+[require-tothrow-message]: docs/rules/require-tothrow-message.md
+[valid-describe]: docs/rules/valid-describe.md
+[valid-expect-in-promise]: docs/rules/valid-expect-in-promise.md
+[valid-expect]: docs/rules/valid-expect.md
+[prefer-todo]: docs/rules/prefer-todo.md
+[fixable-green]: https://img.shields.io/badge/-fixable-green.svg
+[fixable-yellow]: https://img.shields.io/badge/-fixable-yellow.svg
+[recommended]: https://img.shields.io/badge/-recommended-lightgrey.svg

--- a/node_modules/eslint-plugin-jest/docs/rules/consistent-test-it.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/consistent-test-it.md
@@ -1,0 +1,89 @@
+# Have control over `test` and `it` usages (consistent-test-it)
+
+Jest allows you to choose how you want to define your tests, using the `it` or
+the `test` keywords, with multiple permutations for each:
+
+- **it:** `it`, `xit`, `fit`, `it.only`, `it.skip`.
+- **test:** `test`, `xtest`, `test.only`, `test.skip`.
+
+This rule gives you control over the usage of these keywords in your codebase.
+
+## Rule Details
+
+This rule can be configured as follows
+
+```js
+{
+    type: 'object',
+    properties: {
+        fn: {
+            enum: ['it', 'test'],
+        },
+        withinDescribe: {
+            enum: ['it', 'test'],
+        },
+    },
+    additionalProperties: false,
+}
+```
+
+#### fn
+
+Decides whether to use `test` or `it`.
+
+#### withinDescribe
+
+Decides whether to use `test` or `it` within a describe scope.
+
+```js
+/*eslint jest/consistent-test-it: ["error", {"fn": "test"}]*/
+
+test('foo'); // valid
+test.only('foo'); // valid
+
+it('foo'); // invalid
+it.only('foo'); // invalid
+```
+
+```js
+/*eslint jest/consistent-test-it: ["error", {"fn": "it"}]*/
+
+it('foo'); // valid
+it.only('foo'); // valid
+
+test('foo'); // invalid
+test.only('foo'); // invalid
+```
+
+```js
+/*eslint jest/consistent-test-it: ["error", {"fn": "it", "withinDescribe": "test"}]*/
+
+it('foo'); // valid
+describe('foo', function() {
+  test('bar'); // valid
+});
+
+test('foo'); // invalid
+describe('foo', function() {
+  it('bar'); // invalid
+});
+```
+
+### Default configuration
+
+The default configuration forces top level test to use `test` and all tests
+nested within describe to use `it`.
+
+```js
+/*eslint jest/consistent-test-it: ["error"]*/
+
+test('foo'); // valid
+describe('foo', function() {
+  it('bar'); // valid
+});
+
+it('foo'); // invalid
+describe('foo', function() {
+  test('bar'); // invalid
+});
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/expect-expect.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/expect-expect.md
@@ -1,0 +1,77 @@
+# Enforce assertion to be made in a test body (expect-expect)
+
+Ensure that there is at least one `expect` call made in a test.
+
+## Rule details
+
+This rule triggers when there is no call made to `expect` in a test, to prevent
+users from forgetting to add assertions.
+
+Examples of **incorrect** code for this rule:
+
+```js
+it('should be a test', () => {
+  console.log('no assertion');
+});
+test('should assert something', () => {});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it('should be a test', () => {
+  expect(true).toBeDefined();
+});
+it('should work with callbacks/async', () => {
+  somePromise().then(res => expect(res).toBe('passed'));
+});
+```
+
+## Options
+
+```json
+{
+  "jest/expect-expect": [
+    "error",
+    {
+      "assertFunctionNames": ["expect"]
+    }
+  ]
+}
+```
+
+### `assertFunctionNames`
+
+This array option whitelists the assertion function names to look for.
+
+Examples of **incorrect** code for the `{ "assertFunctionNames": ["expect"] }`
+option:
+
+```js
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect"] }] */
+
+import { expectSaga } from 'redux-saga-test-plan';
+import { addSaga } from '../src/sagas';
+
+test('returns sum', () =>
+  expectSaga(addSaga, 1, 1)
+    .returns(2)
+    .run();
+);
+```
+
+Examples of **correct** code for the
+`{ "assertFunctionNames": ["expect", "expectSaga"] }` option:
+
+```js
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSaga"] }] */
+
+import { expectSaga } from 'redux-saga-test-plan';
+import { addSaga } from '../src/sagas';
+
+test('returns sum', () =>
+  expectSaga(addSaga, 1, 1)
+    .returns(2)
+    .run();
+);
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/lowercase-name.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/lowercase-name.md
@@ -1,0 +1,72 @@
+# Enforce lowercase test names (lowercase-name)
+
+## Rule details
+
+Enforce `it`, `test` and `describe` to have descriptions that begin with a
+lowercase letter. This provides more readable test failures. This rule is not
+enabled by default.
+
+The following pattern is considered a warning:
+
+```js
+it('Adds 1 + 2 to equal 3', () => {
+  expect(sum(1, 2)).toBe(3);
+});
+```
+
+The following pattern is not considered a warning:
+
+```js
+it('adds 1 + 2 to equal 3', () => {
+  expect(sum(1, 2)).toBe(3);
+});
+```
+
+## Options
+
+```json
+{
+  "jest/lowercase-name": [
+    "error",
+    {
+      "ignore": ["describe", "test"]
+    }
+  ]
+}
+```
+
+### `ignore`
+
+This array option whitelists function names so that this rule does not report
+their usage as being incorrect. There are three possible values:
+
+- `"describe"`
+- `"test"`
+- `"it"`
+
+By default, none of these options are enabled (the equivalent of
+`{ "ignore": [] }`).
+
+Example of **correct** code for the `{ "ignore": ["describe"] }` option:
+
+```js
+/* eslint jest/lowercase-name: ["error", { "ignore": ["describe"] }] */
+
+describe('Uppercase description');
+```
+
+Example of **correct** code for the `{ "ignore": ["test"] }` option:
+
+```js
+/* eslint jest/lowercase-name: ["error", { "ignore": ["test"] }] */
+
+test('Uppercase description');
+```
+
+Example of **correct** code for the `{ "ignore": ["it"] }` option:
+
+```js
+/* eslint jest/lowercase-name: ["error", { "ignore": ["it"] }] */
+
+it('Uppercase description');
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-alias-methods.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-alias-methods.md
@@ -1,0 +1,46 @@
+# Don't use alias methods (no-alias-methods)
+
+Several Jest methods have alias names, such as `toThrow` having the alias of
+`toThrowError`. This rule ensures that only the canonical name as used in the
+Jest documentation is used in the code. This makes it easier to search for all
+occurrences of the method within code, and it ensures consistency among the
+method names used.
+
+## Rule details
+
+This rule triggers a warning if the alias name, rather than the canonical name,
+of a method is used.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+expect(a).toBeCalled();
+expect(a).toBeCalledTimes();
+expect(a).toBeCalledWith();
+expect(a).lastCalledWith();
+expect(a).nthCalledWith();
+expect(a).toReturn();
+expect(a).toReturnTimes();
+expect(a).toReturnWith();
+expect(a).lastReturnedWith();
+expect(a).nthReturnedWith();
+expect(a).toThrowError();
+```
+
+The following patterns are not considered warnings:
+
+```js
+expect(a).toHaveBeenCalled();
+expect(a).toHaveBeenCalledTimes();
+expect(a).toHaveBeenCalledWith();
+expect(a).toHaveBeenLastCalledWith();
+expect(a).toHaveBeenNthCalledWith();
+expect(a).toHaveReturned();
+expect(a).toHaveReturnedTimes();
+expect(a).toHaveReturnedWith();
+expect(a).toHaveLastReturnedWith();
+expect(a).toHaveNthReturnedWith();
+expect(a).toThrow();
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-disabled-tests.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-disabled-tests.md
@@ -1,0 +1,65 @@
+# Disallow disabled tests (no-disabled-tests)
+
+Jest has a feature that allows you to temporarily mark tests as disabled. This
+feature is often helpful while debugging or to create placeholders for future
+tests. Before committing changes we may want to check that all tests are
+running.
+
+This rule raises a warning about disabled tests.
+
+## Rule Details
+
+There are a number of ways to disable tests in Jest:
+
+- by appending `.skip` to the test-suite or test-case
+- by prepending the test function name with `x`
+- by declaring a test with a name but no function body
+- by making a call to `pending()` anywhere within the test
+
+The following patterns are considered warnings:
+
+```js
+describe.skip('foo', () => {});
+it.skip('foo', () => {});
+test.skip('foo', () => {});
+
+describe['skip']('bar', () => {});
+it['skip']('bar', () => {});
+test['skip']('bar', () => {});
+
+xdescribe('foo', () => {});
+xit('foo', () => {});
+xtest('foo', () => {});
+
+it('bar');
+test('bar');
+
+it('foo', () => {
+  pending();
+});
+```
+
+These patterns would not be considered warnings:
+
+```js
+describe('foo', () => {});
+it('foo', () => {});
+test('foo', () => {});
+
+describe.only('bar', () => {});
+it.only('bar', () => {});
+test.only('bar', () => {});
+```
+
+### Limitations
+
+The plugin looks at the literal function names within test code, so will not
+catch more complex examples of disabled tests, such as:
+
+```js
+const testSkip = test.skip;
+testSkip('skipped test', () => {});
+
+const myTest = test;
+myTest('does not have function body');
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-empty-title.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-empty-title.md
@@ -1,0 +1,36 @@
+# Disallow empty titles
+
+Having an empty string as your test title is pretty useless. This rule reports
+an error if it finds an empty string as s test title.
+
+This rule is not auto-fixable.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+describe('', () => {});
+describe('foo', () => {
+  it('', () => {});
+});
+it('', () => {});
+test('', () => {});
+xdescribe('', () => {});
+xit('', () => {});
+xtest('', () => {});
+```
+
+These patterns would not be considered warnings:
+
+```js
+describe('foo', () => {});
+describe('foo', () => {
+  it('bar', () => {});
+});
+test('foo', () => {});
+it('foo', () => {});
+xdescribe('foo', () => {});
+xit('foo', () => {});
+xtest('foo', () => {});
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-focused-tests.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-focused-tests.md
@@ -1,0 +1,46 @@
+# Disallow focused tests (no-focused-tests)
+
+Jest has a feature that allows you to focus tests by appending `.only` or
+prepending `f` to a test-suite or a test-case. This feature is really helpful to
+debug a failing test, so you don’t have to execute all of your tests. After you
+have fixed your test and before committing the changes you have to remove
+`.only` to ensure all tests are executed on your build system.
+
+This rule reminds you to remove `.only` from your tests by raising a warning
+whenever you are using the exclusivity feature.
+
+## Rule Details
+
+This rule looks for every `describe.only`, `it.only`, `test.only`, `fdescribe`,
+`fit` and `ftest` occurrences within the source code. Of course there are some
+edge-cases which can’t be detected by this rule e.g.:
+
+```js
+const describeOnly = describe.only;
+describeOnly.apply(describe);
+```
+
+The following patterns are considered warnings:
+
+```js
+describe.only('foo', () => {});
+it.only('foo', () => {});
+describe['only']('bar', () => {});
+it['only']('bar', () => {});
+test.only('foo', () => {});
+test['only']('bar', () => {});
+fdescribe('foo', () => {});
+fit('foo', () => {});
+ftest('bar', () => {});
+```
+
+These patterns would not be considered warnings:
+
+```js
+describe('foo', () => {});
+it('foo', () => {});
+describe.skip('bar', () => {});
+it.skip('bar', () => {});
+test('foo', () => {});
+test.skip('bar', () => {});
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-hooks.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-hooks.md
@@ -1,0 +1,175 @@
+# Disallow setup and teardown hooks (no-hooks)
+
+Jest provides global functions for setup and teardown tasks, which are called
+before/after each test case and each test suite. The use of these hooks promotes
+shared state between tests.
+
+## Rule Details
+
+This rule reports for the following function calls:
+
+- `beforeAll`
+- `beforeEach`
+- `afterAll`
+- `afterEach`
+
+Examples of **incorrect** code for this rule:
+
+```js
+/* eslint jest/no-hooks: "error" */
+
+function setupFoo(options) {
+  /* ... */
+}
+
+function setupBar(options) {
+  /* ... */
+}
+
+describe('foo', () => {
+  let foo;
+
+  beforeEach(() => {
+    foo = setupFoo();
+  });
+
+  afterEach(() => {
+    foo = null;
+  });
+
+  it('does something', () => {
+    expect(foo.doesSomething()).toBe(true);
+  });
+
+  describe('with bar', () => {
+    let bar;
+
+    beforeEach(() => {
+      bar = setupBar();
+    });
+
+    afterEach(() => {
+      bar = null;
+    });
+
+    it('does something with bar', () => {
+      expect(foo.doesSomething(bar)).toBe(true);
+    });
+  });
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint jest/no-hooks: "error" */
+
+function setupFoo(options) {
+  /* ... */
+}
+
+function setupBar(options) {
+  /* ... */
+}
+
+describe('foo', () => {
+  it('does something', () => {
+    const foo = setupFoo();
+    expect(foo.doesSomething()).toBe(true);
+  });
+
+  it('does something with bar', () => {
+    const foo = setupFoo();
+    const bar = setupBar();
+    expect(foo.doesSomething(bar)).toBe(true);
+  });
+});
+```
+
+## Options
+
+```json
+{
+  "jest/no-hooks": [
+    "error",
+    {
+      "allow": ["afterEach", "afterAll"]
+    }
+  ]
+}
+```
+
+### `allow`
+
+This array option whitelists setup and teardown hooks so that this rule does not
+report their usage as being incorrect. There are four possible values:
+
+- `"beforeAll"`
+- `"beforeEach"`
+- `"afterAll"`
+- `"afterEach"`
+
+By default, none of these options are enabled (the equivalent of
+`{ "allow": [] }`).
+
+Examples of **incorrect** code for the `{ "allow": ["afterEach"] }` option:
+
+```js
+/* eslint jest/no-hooks: ["error", { "allow": ["afterEach"] }] */
+
+function setupFoo(options) {
+  /* ... */
+}
+
+let foo;
+
+beforeEach(() => {
+  foo = setupFoo();
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+test('foo does this', () => {
+  // ...
+});
+
+test('foo does that', () => {
+  // ...
+});
+```
+
+Examples of **correct** code for the `{ "allow": ["afterEach"] }` option:
+
+```js
+/* eslint jest/no-hooks: ["error", { "allow": ["afterEach"] }] */
+
+function setupFoo(options) {
+  /* ... */
+}
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+test('foo does this', () => {
+  const foo = setupFoo();
+  // ...
+});
+
+test('foo does that', () => {
+  const foo = setupFoo();
+  // ...
+});
+```
+
+## When Not To Use It
+
+If you prefer using the setup and teardown hooks provided by Jest, you can
+safely disable this rule.
+
+## Further Reading
+
+- [Jest docs - Setup and Teardown](https://facebook.github.io/jest/docs/en/setup-teardown.html)
+- [@jamiebuilds Twitter thread](https://twitter.com/jamiebuilds/status/954906997169664000)

--- a/node_modules/eslint-plugin-jest/docs/rules/no-identical-title.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-identical-title.md
@@ -1,0 +1,52 @@
+# Disallow identical titles (no-identical-title)
+
+Having identical titles for two different tests or test suites may create
+confusion. For example, when a test with the same title as another test in the
+same test suite fails, it is harder to know which one failed and thus harder to
+fix.
+
+## Rule Details
+
+This rule looks at the title of every test and test suites. It will report when
+two test suites or two test cases at the same level of a test suite have the
+same title.
+
+The following patterns are considered warnings:
+
+```js
+describe('foo', () => {
+  it('should do bar', () => {});
+  it('should do bar', () => {}); // Has the same title as the previous test
+
+  describe('baz', () => {
+    // ...
+  });
+
+  describe('baz', () => {
+    // Has the same title as a previous test suite
+    // ...
+  });
+});
+```
+
+These patterns would not be considered warnings:
+
+```js
+describe('foo', () => {
+  it('should do foo', () => {});
+  it('should do bar', () => {});
+
+  // Has the same name as a parent test suite, which is fine
+  describe('foo', () => {
+    // Has the same name as a test in a parent test suite, which is fine
+    it('should do foo', () => {});
+    it('should work', () => {});
+  });
+
+  describe('baz', () => {
+    // Has the same title as a previous test suite
+    // Has the same name as a test in a sibling test suite, which is fine
+    it('should work', () => {});
+  });
+});
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-jasmine-globals.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-jasmine-globals.md
@@ -1,0 +1,59 @@
+# Disallow Jasmine globals
+
+`jest` uses `jasmine` as a test runner. A side effect of this is that both a
+`jasmine` object, and some jasmine-specific globals, are exposed to the test
+environment. Most functionality offered by Jasmine has been ported to Jest, and
+the Jasmine globals will stop working in the future. Developers should therefore
+migrate to Jest's documented API instead of relying on the undocumented Jasmine
+API.
+
+### Rule details
+
+This rule reports on any usage of Jasmine globals which is not ported to Jest,
+and suggests alternative from Jest's own API.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
+
+test('my test', () => {
+  pending();
+});
+
+test('my test', () => {
+  fail();
+});
+
+test('my test', () => {
+  spyOn(some, 'object');
+});
+
+test('my test', () => {
+  jasmine.createSpy();
+});
+
+test('my test', () => {
+  expect('foo').toEqual(jasmine.anything());
+});
+```
+
+The following patterns would not be considered warnings:
+
+```js
+jest.setTimeout(5000);
+
+test('my test', () => {
+  jest.spyOn(some, 'object');
+});
+
+test('my test', () => {
+  jest.fn();
+});
+
+test('my test', () => {
+  expect('foo').toEqual(expect.anything());
+});
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-jest-import.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-jest-import.md
@@ -1,0 +1,20 @@
+# Disallow importing Jest(no-jest-import)
+
+The `jest` object is automatically in scope within every test file. The methods
+in the `jest` object help create mocks and let you control Jest's overall
+behavior. It is therefore completely unnecessary to import in `jest`, as Jest
+doesn't export anything in the first place.
+
+### Rule details
+
+This rule reports on any importing of Jest.
+
+To name a few: `var jest = require('jest');` `const jest = require('jest');`
+`import jest from 'jest';` `import {jest as test} from 'jest';`
+
+There is no correct usage of this code, other than to not import `jest` in the
+first place.
+
+## Further Reading
+
+\*[The Jest Object](https://facebook.github.io/jest/docs/en/jest-object.html)

--- a/node_modules/eslint-plugin-jest/docs/rules/no-large-snapshots.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-large-snapshots.md
@@ -1,0 +1,112 @@
+# disallow large snapshots (no-large-snapshots)
+
+When using Jest's snapshot capability one should be mindful of the size of
+created snapshots. As a best practice snapshots should be limited in size in
+order to be more manageable and reviewable. A stored snapshot is only as good as
+its review and as such keeping it short, sweet, and readable is important to
+allow for thorough reviews.
+
+## Usage
+
+Because Jest snapshots are written with back-ticks (\` \`) which are only valid
+with
+[ES2015 onwards](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
+you should set `parserOptions` in your config to at least allow ES2015 in order
+to use this rule:
+
+```js
+parserOptions: {
+  ecmaVersion: 2015,
+},
+```
+
+## Rule Details
+
+This rule looks at all Jest inline and external snapshots (files with `.snap`
+extension) and validates that each stored snapshot within those files does not
+exceed 50 lines (by default, this is configurable as explained in `Options`
+section below).
+
+Example of **incorrect** code for this rule:
+
+```js
+exports[`a large snapshot 1`] = `
+line 1
+line 2
+line 3
+line 4
+line 5
+line 6
+line 7
+line 8
+line 9
+line 10
+line 11
+line 12
+line 13
+line 14
+line 15
+line 16
+line 17
+line 18
+line 19
+line 20
+line 21
+line 22
+line 23
+line 24
+line 25
+line 26
+line 27
+line 28
+line 29
+line 30
+line 31
+line 32
+line 33
+line 34
+line 35
+line 36
+line 37
+line 38
+line 39
+line 40
+line 41
+line 42
+line 43
+line 44
+line 45
+line 46
+line 47
+line 48
+line 49
+line 50
+line 51
+`;
+```
+
+Example of **correct** code for this rule:
+
+```js
+exports[`a more manageable and readable snapshot 1`] = `
+line 1
+line 2
+line 3
+line 4
+`;
+```
+
+## Options
+
+This rule has option for modifying the max number of lines allowed for a
+snapshot:
+
+In an `eslintrc` file:
+
+```json
+...
+  "rules": {
+    "jest/no-large-snapshots": ["warn", { "maxSize": 12 }]
+  }
+...
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-mocks-import.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-mocks-import.md
@@ -1,0 +1,27 @@
+# Disallow manually importing from `__mocks__` (no-mocks-import)
+
+When using `jest.mock`, your tests (just like the code being tested) should
+import from `./x`, not `./__mocks__/x`. Not following this rule can lead to
+confusion, because you will have multiple instances of the mocked module:
+
+```js
+jest.mock('./x');
+const x1 = require('./x');
+const x2 = require('./__mocks__/x');
+
+test('x', () => {
+  expect(x1).toBe(x2); // fails! They are both instances of `./__mocks__/x`, but not referentially equal
+});
+```
+
+### Rule details
+
+This rule reports imports from a path containing a `__mocks__` component.
+
+Example violations:
+
+```js
+import thing from './__mocks__/index';
+require('./__mocks__/index');
+require('__mocks__');
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-test-callback.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-test-callback.md
@@ -1,0 +1,76 @@
+# Avoid using a callback in asynchronous tests (no-test-callback)
+
+Jest allows you to pass a callback to test definitions, typically called `done`,
+that is later invoked to indicate that the asynchronous test is complete.
+
+However, that means that if your test throws (e.g. because of a failing
+assertion), `done` will never be called unless you manually use `try-catch`.
+
+```js
+test('some test', done => {
+  expect(false).toBe(true);
+  done();
+});
+```
+
+The test above will time out instead of failing the assertions, since `done` is
+never called.
+
+Correct way of doing the same thing is to wrap it in `try-catch`.
+
+```js
+test('some test', done => {
+  try {
+    expect(false).toBe(true);
+    done();
+  } catch (e) {
+    done(e);
+  }
+});
+```
+
+However, Jest supports a second way of having asynchronous tests - using
+promises.
+
+```js
+test('some test', () => {
+  return new Promise(done => {
+    expect(false).toBe(true);
+    done();
+  });
+});
+```
+
+Even though `done` is never called here, the Promise will still reject, and Jest
+will report the assertion error correctly.
+
+## Rule details
+
+This rule triggers a warning if you have a `done` callback in your test.
+
+The following patterns are considered warnings:
+
+```js
+test('myFunction()', done => {
+  // ...
+});
+
+test('myFunction()', function(done) {
+  // ...
+});
+```
+
+The following patterns are not considered warnings:
+
+```js
+test('myFunction()', () => {
+  expect(myFunction()).toBeTruthy();
+});
+
+test('myFunction()', () => {
+  return new Promise(done => {
+    expect(myFunction()).toBeTruthy();
+    done();
+  });
+});
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-test-prefixes.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-test-prefixes.md
@@ -1,0 +1,32 @@
+# Use `.only` and `.skip` over `f` and `x` (no-test-prefixes)
+
+Jest allows you to choose how you want to define focused and skipped tests, with
+multiple permutations for each:
+
+- **only & skip:** `it.only`, `test.only`, `describe.only`, `it.skip`,
+  `test.skip`, `describe.skip`.
+- **'f' & 'x':** `fit`, `fdescribe`, `xit`, `xtest`, `xdescribe`.
+
+This rule enforces usages from the **only & skip** list.
+
+## Rule details
+
+This rule triggers a warning if you use one of the keywords from the **'f' &
+'x'** list to focus/skip a test.
+
+```js
+/*eslint jest/no-test-prefixes: "error"*/
+
+it.only('foo'); // valid
+test.only('foo'); // valid
+describe.only('foo'); // valid
+it.skip('foo'); // valid
+test.skip('foo'); // valid
+describe.skip('foo'); // valid
+
+fit('foo'); // invalid
+fdescribe('foo'); // invalid
+xit('foo'); // invalid
+xtest('foo'); // invalid
+xdescribe('foo'); // invalid
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-test-return-statement.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-test-return-statement.md
@@ -1,0 +1,47 @@
+# Disallow explicitly returning from tests (no-test-return-statement)
+
+Tests in Jest should be void and not return values.
+
+If you are returning Promises then you should update the test to use
+`async/await`.
+
+## Rule details
+
+This rule triggers a warning if you use a return statement inside of a test
+body.
+
+```js
+/*eslint jest/no-test-return-statement: "error"*/
+
+// valid:
+
+it('noop', function() {});
+
+test('noop', () => {});
+
+test('one arrow', () => expect(1).toBe(1));
+
+test('empty');
+
+test('one', () => {
+  expect(1).toBe(1);
+});
+
+it('one', function() {
+  expect(1).toBe(1);
+});
+
+it('returning a promise', async () => {
+  await new Promise(res => setTimeout(res, 100));
+  expect(1).toBe(1);
+});
+
+// invalid:
+test('return an expect', () => {
+  return expect(1).toBe(1);
+});
+
+it('returning a promise', function() {
+  return new Promise(res => setTimeout(res, 100)).then(() => expect(1).toBe(1));
+});
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/no-truthy-falsy.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/no-truthy-falsy.md
@@ -1,0 +1,32 @@
+# Disallow using `toBeTruthy()` & `toBeFalsy()` (no-truthy-falsy)
+
+Tests against boolean values should assert true or false. Asserting `toBeTruthy`
+or `toBeFalsy` matches non-boolean values as well and encourages weaker tests.
+
+For example, `expect(someBoolean).toBeFalsy()` passes when
+`someBoolean === null`, and when `someBoolean === false`.
+
+Similarly, `expect(someBoolean).toBeTruthy()` passes when `someBoolean === []`,
+and when `someBoolean === 'false'` (note that `'false'` is a string).
+
+## Rule details
+
+This rule triggers a warning if `toBeTruthy()` or `toBeFalsy()` are used.
+
+This rule is disabled by default.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+expect(someValue).toBeTruthy();
+expect(someValue).toBeFalsy();
+```
+
+The following patterns are not considered warnings:
+
+```js
+expect(someValue).toBe(true);
+expect(someValue).toBe(false);
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/prefer-called-with.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/prefer-called-with.md
@@ -1,0 +1,32 @@
+# Suggest using `toBeCalledWith` OR `toHaveBeenCalledWith` (prefer-called-with)
+
+The `toBeCalled()` matcher is used to assert that a mock function has been
+called one or more times, without checking the arguments passed. The assertion
+is stronger when arguments are also validated using the `toBeCalledWith()`
+matcher. When some arguments are difficult to check, using generic match like
+`expect.anything()` at least enforces number and position of arguments.
+
+This rule warns if the form without argument checking is used, except for `.not`
+enforcing a function has never been called.
+
+## Rule details
+
+The following patterns are warnings:
+
+```js
+expect(someFunction).toBeCalled();
+
+expect(someFunction).toHaveBeenCalled();
+```
+
+The following patterns are not warnings:
+
+```js
+expect(noArgsFunction).toBeCalledWith();
+
+expect(roughArgsFunction).toBeCalledWith(expect.anything(), expect.any(Date));
+
+expect(anyArgsFunction).toBeCalledTimes(1);
+
+expect(uncalledFunction).not.toBeCalled();
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/prefer-expect-assertions.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/prefer-expect-assertions.md
@@ -1,0 +1,57 @@
+# Suggest using `expect.assertions()` OR `expect.hasAssertions()` (prefer-expect-assertions)
+
+Ensure every test to have either `expect.assertions(<number of assertions>)` OR
+`expect.hasAssertions()` as its first expression.
+
+## Rule details
+
+This rule triggers a warning if,
+
+- `expect.assertions(<number of assertions>)` OR `expect.hasAssertions()` is not
+  present as first statement in a test, e.g.:
+
+```js
+test('my test', () => {
+  expect(someThing()).toEqual('foo');
+});
+```
+
+- `expect.assertions(<number of assertions>)` is the first statement in a test
+  where argument passed to `expect.assertions(<number of assertions>)` is not a
+  valid number, e.g.:
+
+```js
+test('my test', () => {
+  expect.assertions('1');
+  expect(someThing()).toEqual('foo');
+});
+```
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+test("my test", () => {
+  expect.assertions("1");
+  expect(someThing()).toEqual("foo");
+});
+
+test("my test", () => {
+  expect.(someThing()).toEqual("foo");
+});
+```
+
+The following patterns would not be considered warnings:
+
+```js
+test('my test', () => {
+  expect.assertions(1);
+  expect(someThing()).toEqual('foo');
+});
+
+test('my test', () => {
+  expect.hasAssertions();
+  expect(someThing()).toEqual('foo');
+});
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/prefer-inline-snapshots.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/prefer-inline-snapshots.md
@@ -1,0 +1,30 @@
+# Suggest using inline snapshots (prefer-inline-snapshots)
+
+In order to make snapshot tests more managable and reviewable
+`toMatchInlineSnapshot()` and `toThrowErrorMatchingInlineSnapshot` should be
+used to write the snapshots inline in the test file.
+
+## Rule details
+
+This rule triggers a warning if `toMatchSnapshot()` or
+`toThrowErrorMatchingSnapshot` is used to capture a snapshot.
+
+The following pattern is considered warning:
+
+```js
+expect(obj).toMatchSnapshot();
+```
+
+```js
+expect(error).toThrowErrorMatchingSnapshot();
+```
+
+The following pattern is not warning:
+
+```js
+expect(obj).toMatchInlineSnapshot();
+```
+
+```js
+expect(error).toThrowErrorMatchingInlineSnapshot();
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/prefer-spy-on.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/prefer-spy-on.md
@@ -1,0 +1,41 @@
+# Suggest using `jest.spyOn()` (prefer-spy-on)
+
+When mocking a function by overwriting a property you have to manually restore
+the original implementation when cleaning up. When using `jest.spyOn()` Jest
+keeps track of changes, and they can be restored with `jest.restoreAllMocks()`,
+`mockFn.mockRestore()` or by setting `restoreMocks` to `true` in the Jest
+config.
+
+Note: The mock created by `jest.spyOn()` still behaves the same as the original
+function. The original function can be overwritten with
+`mockFn.mockImplementation()` or by some of the
+[other mock functions](https://jestjs.io/docs/en/mock-function-api).
+
+```js
+Date.now = jest.fn(); // Original behaviour lost, returns undefined
+
+jest.spyOn(Date, 'now'); // Turned into a mock function but behaviour hasn't changed
+jest.spyOn(Date, 'now').mockImplementation(() => 10); // Will always return 10
+jest.spyOn(Date, 'now').mockReturnValue(10); // Will always return 10
+```
+
+## Rule details
+
+This rule triggers a warning if an object's property is overwritten with a jest
+mock.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+Date.now = jest.fn();
+Date.now = jest.fn(() => 10);
+```
+
+These patterns would not be considered warnings:
+
+```js
+jest.spyOn(Date, 'now');
+jest.spyOn(Date, 'now').mockImplementation(() => 10);
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/prefer-strict-equal.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/prefer-strict-equal.md
@@ -1,0 +1,24 @@
+# Suggest using `toStrictEqual()` (prefer-strict-equal)
+
+`toStrictEqual` not only checks that two objects contain the same data but also
+that they have the same structure. It is common to expect objects to not only
+have identical values but also to have identical keys. A stricter equality will
+catch cases where two objects do not have identical keys.
+
+## Rule details
+
+This rule triggers a warning if `toEqual()` is used to assert equality.
+
+### Default configuration
+
+The following pattern is considered warning:
+
+```js
+expect({ a: 'a', b: undefined }).toEqual({ a: 'a' }); // true
+```
+
+The following pattern is not warning:
+
+```js
+expect({ a: 'a', b: undefined }).toStrictEqual({ a: 'a' }); // false
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/prefer-to-be-null.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/prefer-to-be-null.md
@@ -1,0 +1,28 @@
+# Suggest using `toBeNull()` (prefer-to-be-null)
+
+In order to have a better failure message, `toBeNull()` should be used upon
+asserting expections on null value.
+
+## Rule details
+
+This rule triggers a warning if `toBe()` is used to assert a null value.
+
+```js
+expect(null).toBe(null);
+```
+
+This rule is enabled by default.
+
+### Default configuration
+
+The following pattern is considered warning:
+
+```js
+expect(null).toBe(null);
+```
+
+The following pattern is not warning:
+
+```js
+expect(null).toBeNull();
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/prefer-to-be-undefined.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/prefer-to-be-undefined.md
@@ -1,0 +1,28 @@
+# Suggest using `toBeUndefined()` (prefer-to-be-undefined)
+
+In order to have a better failure message, `toBeUndefined()` should be used upon
+asserting expections on undefined value.
+
+## Rule details
+
+This rule triggers a warning if `toBe()` is used to assert a undefined value.
+
+```js
+expect(undefined).toBe(undefined);
+```
+
+This rule is enabled by default.
+
+### Default configuration
+
+The following pattern is considered warning:
+
+```js
+expect(undefined).toBe(undefined);
+```
+
+The following pattern is not warning:
+
+```js
+expect(undefined).toBeUndefined();
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/prefer-to-contain.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/prefer-to-contain.md
@@ -1,0 +1,47 @@
+# Suggest using `toContain()` (prefer-to-contain)
+
+In order to have a better failure message, `toContain()` should be used upon
+asserting expectations on an array containing an object.
+
+## Rule details
+
+This rule triggers a warning if `toBe()` or `isEqual()` is used to assert object
+inclusion in an array
+
+```js
+expect(a.includes(b)).toBe(true);
+```
+
+```js
+expect(a.includes(b)).not.toBe(true);
+```
+
+```js
+expect(a.includes(b)).toBe(false);
+```
+
+### Default configuration
+
+The following patterns are considered a warning:
+
+```js
+expect(a.includes(b)).toBe(true);
+```
+
+```js
+expect(a.includes(b)).not.toBe(true);
+```
+
+```js
+expect(a.includes(b)).toBe(false);
+```
+
+The following patterns are not a warning:
+
+```js
+expect(a).toContain(b);
+```
+
+```js
+expect(a).not.toContain(b);
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/prefer-to-have-length.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/prefer-to-have-length.md
@@ -1,0 +1,29 @@
+# Suggest using `toHaveLength()` (prefer-to-have-length)
+
+In order to have a better failure message, `toHaveLength()` should be used upon
+asserting expectations on object's length property.
+
+## Rule details
+
+This rule triggers a warning if `toBe()` is used to assert object's length
+property.
+
+```js
+expect(files.length).toBe(1);
+```
+
+This rule is enabled by default.
+
+### Default configuration
+
+The following pattern is considered warning:
+
+```js
+expect(files.length).toBe(1);
+```
+
+The following pattern is not warning:
+
+```js
+expect(files).toHaveLength(1);
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/prefer-todo.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/prefer-todo.md
@@ -1,0 +1,28 @@
+# Suggest using `test.todo` (prefer-todo)
+
+When test cases are empty then it is better to mark them as `test.todo` as it
+will be highlighted in the summary output.
+
+## Rule details
+
+This rule triggers a warning if empty test case is used without 'test.todo'.
+
+```js
+test('i need to write this test');
+```
+
+### Default configuration
+
+The following pattern is considered warning:
+
+```js
+test('i need to write this test'); // Unimplemented test case
+test('i need to write this test', () => {}); // Empty test case body
+test.skip('i need to write this test', () => {}); // Empty test case body
+```
+
+The following pattern is not warning:
+
+```js
+test.todo('i need to write this test');
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/require-tothrow-message.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/require-tothrow-message.md
@@ -1,0 +1,29 @@
+# Require a message for `toThrow()` (require-tothrow-message)
+
+`toThrow()`, and its alias `toThrowError()`, are used to check if an error is
+thrown by a function call, such as in `expect(() => a()).toThrow()`. However, if
+no message is defined, then the test will pass for any thrown error. Requiring a
+message ensures that the intended error is thrown.
+
+## Rule details
+
+This rule triggers a warning if `toThrow()` or `toThrowError()` is used without
+an error message.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+expect(() => a()).toThrow();
+
+expect(() => a()).toThrowError();
+```
+
+The following patterns are not considered warnings:
+
+```js
+expect(() => a()).toThrow('a');
+
+expect(() => a()).toThrowError('a');
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/valid-describe.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/valid-describe.md
@@ -1,0 +1,56 @@
+# Enforce valid `describe()` callback (valid-describe)
+
+Using an improper `describe()` callback function can lead to unexpected test
+errors.
+
+## Rule Details
+
+This rule validates that the second parameter of a `describe()` function is a
+callback function. This callback function:
+
+- should not be
+  [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
+- should not contain any parameters
+- should not contain any `return` statements
+
+The following `describe` function aliases are also validated:
+
+- `describe`
+- `describe.only`
+- `describe.skip`
+- `fdescribe`
+- `xdescribe`
+
+The following patterns are considered warnings:
+
+```js
+// Async callback functions are not allowed
+describe('myFunction()', async () => {
+  // ...
+});
+
+// Callback function parameters are not allowed
+describe('myFunction()', done => {
+  // ...
+});
+
+//
+describe('myFunction', () => {
+  // No return statements are allowed in block of a callback function
+  return Promise.resolve().then(() => {
+    it('breaks', () => {
+      throw new Error('Fail');
+    });
+  });
+});
+```
+
+The following patterns are not considered warnings:
+
+```js
+describe('myFunction()', () => {
+  it('returns a truthy value', () => {
+    expect(myFunction()).toBeTruthy();
+  });
+});
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/valid-expect-in-promise.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/valid-expect-in-promise.md
@@ -1,0 +1,33 @@
+# Enforce having return statement when testing with promises (valid-expect-in-promise)
+
+Ensure to return promise when having assertions in `then` or `catch` block of
+promise
+
+## Rule details
+
+This rule triggers a warning if,
+
+- test is having assertions in `then` or `catch` block of a promise
+- and that promise is not returned from the test
+
+### Default configuration
+
+The following pattern is considered warning:
+
+```js
+it('promise test', () => {
+  somePromise.then(data => {
+    expect(data).toEqual('foo');
+  });
+});
+```
+
+The following pattern is not warning:
+
+```js
+it('promise test', () => {
+  return somePromise.then(data => {
+    expect(data).toEqual('foo');
+  });
+});
+```

--- a/node_modules/eslint-plugin-jest/docs/rules/valid-expect.md
+++ b/node_modules/eslint-plugin-jest/docs/rules/valid-expect.md
@@ -1,0 +1,45 @@
+# Enforce valid `expect()` usage (valid-expect)
+
+Ensure `expect()` is called with a single argument and there is an actual
+expectation made.
+
+## Rule details
+
+This rule triggers a warning if `expect()` is called with more than one argument
+or without arguments. It would also issue a warning if there is nothing called
+on `expect()`, e.g.:
+
+```js
+expect();
+expect('something');
+```
+
+or when a matcher function was not called, e.g.:
+
+```js
+expect(true).toBeDefined;
+```
+
+This rule is enabled by default.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+expect();
+expect().toEqual('something');
+expect('something', 'else');
+expect('something');
+expect(true).toBeDefined;
+expect(Promise.resolve('hello')).resolves;
+```
+
+The following patterns are not warnings:
+
+```js
+expect('something').toEqual('something');
+expect([1, 2, 3]).toEqual([1, 2, 3]);
+expect(true).toBeDefined();
+expect(Promise.resolve('hello')).resolves.toEqual('hello');
+```

--- a/node_modules/eslint-plugin-jest/index.js
+++ b/node_modules/eslint-plugin-jest/index.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const rules = fs
+  .readdirSync(path.join(__dirname, 'rules'))
+  .filter(rule => rule !== '__tests__' && rule !== 'util.js')
+  .map(rule => path.basename(rule, '.js'))
+  .reduce(
+    (acc, curr) => Object.assign(acc, { [curr]: require(`./rules/${curr}`) }),
+    {}
+  );
+
+const snapshotProcessor = require('./processors/snapshot-processor');
+
+module.exports = {
+  configs: {
+    recommended: {
+      plugins: ['jest'],
+      env: {
+        'jest/globals': true,
+      },
+      rules: {
+        'jest/no-alias-methods': 'warn',
+        'jest/no-disabled-tests': 'warn',
+        'jest/no-focused-tests': 'error',
+        'jest/no-identical-title': 'error',
+        'jest/no-jest-import': 'error',
+        // 'jest/no-mocks-import': 'error',
+        'jest/no-jasmine-globals': 'warn',
+        'jest/no-test-prefixes': 'error',
+        'jest/valid-describe': 'error',
+        'jest/valid-expect': 'error',
+        'jest/valid-expect-in-promise': 'error',
+      },
+    },
+    style: {
+      plugins: ['jest'],
+      rules: {
+        'jest/prefer-to-be-null': 'error',
+        'jest/prefer-to-be-undefined': 'error',
+        'jest/prefer-to-contain': 'error',
+        'jest/prefer-to-have-length': 'error',
+      },
+    },
+  },
+  environments: {
+    globals: {
+      globals: {
+        afterAll: false,
+        afterEach: false,
+        beforeAll: false,
+        beforeEach: false,
+        describe: false,
+        expect: false,
+        fit: false,
+        it: false,
+        jasmine: false,
+        jest: false,
+        pending: false,
+        pit: false,
+        require: false,
+        test: false,
+        xdescribe: false,
+        xit: false,
+        xtest: false,
+      },
+    },
+  },
+  processors: {
+    '.snap': snapshotProcessor,
+  },
+  rules,
+};

--- a/node_modules/eslint-plugin-jest/package.json
+++ b/node_modules/eslint-plugin-jest/package.json
@@ -1,0 +1,131 @@
+{
+  "_from": "eslint-plugin-jest",
+  "_id": "eslint-plugin-jest@22.5.1",
+  "_inBundle": false,
+  "_integrity": "sha512-c3WjZR/HBoi4GedJRwo2OGHa8Pzo1EbSVwQ2HFzJ+4t2OoYM7Alx646EH/aaxZ+9eGcPiq0FT0UGkRuFFx2FHg==",
+  "_location": "/eslint-plugin-jest",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "eslint-plugin-jest",
+    "name": "eslint-plugin-jest",
+    "escapedName": "eslint-plugin-jest",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#DEV:/",
+    "#USER"
+  ],
+  "_resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.5.1.tgz",
+  "_shasum": "a31dfe9f9513c6af7c17ece4c65535a1370f060b",
+  "_spec": "eslint-plugin-jest",
+  "_where": "/Users/kevinbarabash/khan/devtools/khan-linter",
+  "author": {
+    "name": "Jonathan Kim",
+    "email": "hello@jkimbo.com",
+    "url": "jkimbo.com"
+  },
+  "bugs": {
+    "url": "https://github.com/jest-community/eslint-plugin-jest/issues"
+  },
+  "bundleDependencies": false,
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
+  },
+  "deprecated": false,
+  "description": "Eslint rules for Jest",
+  "devDependencies": {
+    "@commitlint/cli": "^7.0.0",
+    "@commitlint/config-conventional": "^7.0.1",
+    "eslint": "^5.1.0",
+    "eslint-config-prettier": "^4.1.0",
+    "eslint-plugin-eslint-plugin": "^2.0.0",
+    "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-prettier": "^3.0.0",
+    "husky": "^1.0.1",
+    "jest": "^24.0.0",
+    "jest-runner-eslint": "^0.7.1",
+    "lint-staged": "^8.0.4",
+    "prettier": "^1.10.2",
+    "prettylint": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=6"
+  },
+  "files": [
+    "docs/",
+    "rules/",
+    "processors/",
+    "index.js"
+  ],
+  "homepage": "https://github.com/jest-community/eslint-plugin-jest#readme",
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
+      "pre-commit": "lint-staged"
+    }
+  },
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    },
+    "projects": [
+      {
+        "displayName": "test",
+        "testEnvironment": "node"
+      },
+      {
+        "displayName": "lint",
+        "runner": "jest-runner-eslint",
+        "testMatch": [
+          "<rootDir>/**/*.js"
+        ]
+      }
+    ]
+  },
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "license": "MIT",
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ],
+    "*.{md,json}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "name": "eslint-plugin-jest",
+  "peerDependencies": {
+    "eslint": ">=5"
+  },
+  "prettier": {
+    "proseWrap": "always",
+    "singleQuote": true,
+    "trailingComma": "es5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jest-community/eslint-plugin-jest.git"
+  },
+  "scripts": {
+    "lint": "eslint . --ignore-pattern '!.eslintrc.js'",
+    "prettylint": "prettylint docs/**/*.md README.md package.json",
+    "test": "jest"
+  },
+  "version": "22.5.1"
+}

--- a/node_modules/eslint-plugin-jest/processors/__tests__/snapshot-processor.test.js
+++ b/node_modules/eslint-plugin-jest/processors/__tests__/snapshot-processor.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const snapshotProcessor = require('../snapshot-processor');
+
+describe('snapshot-processor', () => {
+  it('exports an object with preprocess and postprocess functions', () => {
+    expect(snapshotProcessor).toMatchObject({
+      preprocess: expect.any(Function),
+      postprocess: expect.any(Function),
+    });
+  });
+
+  describe('preprocess function', () => {
+    it('should pass on untouched source code to source array', () => {
+      const { preprocess } = snapshotProcessor;
+      const sourceCode = "const name = 'johnny bravo';";
+      const result = preprocess(sourceCode);
+
+      expect(result).toEqual([sourceCode]);
+    });
+  });
+
+  describe('postprocess function', () => {
+    it('should only return messages about snapshot specific rules', () => {
+      const { postprocess } = snapshotProcessor;
+      const result = postprocess([
+        [
+          { ruleId: 'no-console' },
+          { ruleId: 'global-require' },
+          { ruleId: 'jest/no-large-snapshots' },
+        ],
+      ]);
+
+      expect(result).toEqual([{ ruleId: 'jest/no-large-snapshots' }]);
+    });
+  });
+});

--- a/node_modules/eslint-plugin-jest/processors/snapshot-processor.js
+++ b/node_modules/eslint-plugin-jest/processors/snapshot-processor.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins
+const preprocess = source => [source];
+
+const postprocess = messages =>
+  messages[0].filter(
+    // snapshot files should only be linted with snapshot specific rules
+    message => message.ruleId === 'jest/no-large-snapshots'
+  );
+
+module.exports = {
+  preprocess,
+  postprocess,
+};

--- a/node_modules/eslint-plugin-jest/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`no-large-snapshots ExpressionStatement function should report if maxSize is zero 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "lineCount": 1,
+      "lineLimit": 0,
+    },
+    "message": "Expected to not encounter a Jest snapshot but was found with {{ lineCount }} lines long",
+    "node": Object {
+      "loc": Object {
+        "end": Object {
+          "line": 2,
+        },
+        "start": Object {
+          "line": 1,
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`no-large-snapshots ExpressionStatement function should report if node has more lines of code than number given in sizeThreshold option 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "lineCount": 83,
+      "lineLimit": 70,
+    },
+    "message": "Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long",
+    "node": Object {
+      "loc": Object {
+        "end": Object {
+          "line": 103,
+        },
+        "start": Object {
+          "line": 20,
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`no-large-snapshots ExpressionStatement function should report if node has more than 50 lines of code and no sizeThreshold option is passed 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "lineCount": 52,
+      "lineLimit": 50,
+    },
+    "message": "Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long",
+    "node": Object {
+      "loc": Object {
+        "end": Object {
+          "line": 53,
+        },
+        "start": Object {
+          "line": 1,
+        },
+      },
+    },
+  },
+]
+`;

--- a/node_modules/eslint-plugin-jest/rules/__tests__/consistent-test-it.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/consistent-test-it.test.js
@@ -1,0 +1,393 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../consistent-test-it');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+ruleTester.run('consistent-test-it with fn=test', rule, {
+  valid: [
+    {
+      code: 'test("foo")',
+      options: [{ fn: 'test' }],
+    },
+    {
+      code: 'test.only("foo")',
+      options: [{ fn: 'test' }],
+    },
+    {
+      code: 'test.skip("foo")',
+      options: [{ fn: 'test' }],
+    },
+    {
+      code: 'xtest("foo")',
+      options: [{ fn: 'test' }],
+    },
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      options: [{ fn: 'test' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'it("foo")',
+      options: [{ fn: 'test' }],
+      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      output: 'test("foo")',
+    },
+    {
+      code: 'xit("foo")',
+      options: [{ fn: 'test' }],
+      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      output: 'xtest("foo")',
+    },
+    {
+      code: 'fit("foo")',
+      options: [{ fn: 'test' }],
+      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      output: 'test.only("foo")',
+    },
+    {
+      code: 'it.skip("foo")',
+      options: [{ fn: 'test' }],
+      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      output: 'test.skip("foo")',
+    },
+    {
+      code: 'it.only("foo")',
+      options: [{ fn: 'test' }],
+      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      output: 'test.only("foo")',
+    },
+    {
+      code: 'describe("suite", () => { it("foo") })',
+      options: [{ fn: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { test("foo") })',
+    },
+  ],
+});
+
+ruleTester.run('consistent-test-it with fn=it', rule, {
+  valid: [
+    {
+      code: 'it("foo")',
+      options: [{ fn: 'it' }],
+    },
+    {
+      code: 'fit("foo")',
+      options: [{ fn: 'it' }],
+    },
+    {
+      code: 'xit("foo")',
+      options: [{ fn: 'it' }],
+    },
+    {
+      code: 'it.only("foo")',
+      options: [{ fn: 'it' }],
+    },
+    {
+      code: 'it.skip("foo")',
+      options: [{ fn: 'it' }],
+    },
+    {
+      code: 'describe("suite", () => { it("foo") })',
+      options: [{ fn: 'it' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'test("foo")',
+      options: [{ fn: 'it' }],
+      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      output: 'it("foo")',
+    },
+    {
+      code: 'xtest("foo")',
+      options: [{ fn: 'it' }],
+      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      output: 'xit("foo")',
+    },
+    {
+      code: 'test.skip("foo")',
+      options: [{ fn: 'it' }],
+      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      output: 'it.skip("foo")',
+    },
+    {
+      code: 'test.only("foo")',
+      options: [{ fn: 'it' }],
+      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      output: 'it.only("foo")',
+    },
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      options: [{ fn: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it("foo") })',
+    },
+  ],
+});
+
+ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
+  valid: [
+    {
+      code: 'test("foo")',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+    },
+    {
+      code: 'test.only("foo")',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+    },
+    {
+      code: 'test.skip("foo")',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+    },
+    {
+      code: 'xtest("foo")',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+    },
+    {
+      code: '[1,2,3].forEach(() => { test("foo") })',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { test.only("foo") })',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it.only("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { xtest("foo") })',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { xit("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { test.skip("foo") })',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it.skip("foo") })',
+    },
+  ],
+});
+
+ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
+  valid: [
+    {
+      code: 'it("foo")',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+    },
+    {
+      code: 'it.only("foo")',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+    },
+    {
+      code: 'it.skip("foo")',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+    },
+    {
+      code: 'xit("foo")',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+    },
+    {
+      code: '[1,2,3].forEach(() => { it("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'describe("suite", () => { it("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { test("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { it.only("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { test.only("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { xit("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { xtest("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { it.skip("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { test.skip("foo") })',
+    },
+  ],
+});
+
+ruleTester.run(
+  'consistent-test-it with fn=test and withinDescribe=test ',
+  rule,
+  {
+    valid: [
+      {
+        code: 'describe("suite", () => { test("foo") })',
+        options: [{ fn: 'test', withinDescribe: 'test' }],
+      },
+      {
+        code: 'test("foo");',
+        options: [{ fn: 'test', withinDescribe: 'test' }],
+      },
+    ],
+    invalid: [
+      {
+        code: 'describe("suite", () => { it("foo") })',
+        options: [{ fn: 'test', withinDescribe: 'test' }],
+        errors: [
+          { message: "Prefer using 'test' instead of 'it' within describe" },
+        ],
+        output: 'describe("suite", () => { test("foo") })',
+      },
+      {
+        code: 'it("foo")',
+        options: [{ fn: 'test', withinDescribe: 'test' }],
+        errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+        output: 'test("foo")',
+      },
+    ],
+  }
+);
+
+ruleTester.run('consistent-test-it with fn=it and withinDescribe=it ', rule, {
+  valid: [
+    {
+      code: 'describe("suite", () => { it("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'it' }],
+    },
+    {
+      code: 'it("foo")',
+      options: [{ fn: 'it', withinDescribe: 'it' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it("foo") })',
+    },
+    {
+      code: 'test("foo")',
+      options: [{ fn: 'it', withinDescribe: 'it' }],
+      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      output: 'it("foo")',
+    },
+  ],
+});
+
+ruleTester.run('consistent-test-it defaults without config object', rule, {
+  valid: [
+    {
+      code: 'test("foo")',
+    },
+  ],
+  invalid: [
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it("foo") })',
+    },
+  ],
+});
+
+ruleTester.run('consistent-test-it with withinDescribe=it', rule, {
+  valid: [
+    {
+      code: 'test("foo")',
+      options: [{ withinDescribe: 'it' }],
+    },
+    {
+      code: 'describe("suite", () => { it("foo") })',
+      options: [{ withinDescribe: 'it' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'it("foo")',
+      options: [{ withinDescribe: 'it' }],
+      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      output: 'test("foo")',
+    },
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      options: [{ withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it("foo") })',
+    },
+  ],
+});
+
+ruleTester.run('consistent-test-it with withinDescribe=test', rule, {
+  valid: [
+    {
+      code: 'test("foo")',
+      options: [{ withinDescribe: 'test' }],
+    },
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      options: [{ withinDescribe: 'test' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'it("foo")',
+      options: [{ withinDescribe: 'test' }],
+      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      output: 'test("foo")',
+    },
+    {
+      code: 'describe("suite", () => { it("foo") })',
+      options: [{ withinDescribe: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { test("foo") })',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/expect-expect.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/expect-expect.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../expect-expect');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+ruleTester.run('expect-expect', rule, {
+  valid: [
+    'it("should pass", () => expect(true).toBeDefined())',
+    'test("should pass", () => expect(true).toBeDefined())',
+    'it("should pass", () => somePromise().then(() => expect(true).toBeDefined()))',
+    {
+      code:
+        'test("should pass", () => { expect(true).toBeDefined(); foo(true).toBe(true); })',
+      options: [{ assertFunctionNames: ['expect', 'foo'] }],
+    },
+    {
+      code: 'it("should return undefined",() => expectSaga(mySaga).returns());',
+      options: [{ assertFunctionNames: ['expectSaga'] }],
+    },
+    {
+      code: [
+        'test("verifies the function call", () => {',
+        '  td.verify(someFunctionCall())',
+        '})',
+      ].join('\n'),
+      options: [{ assertFunctionNames: ['td.verify'] }],
+    },
+  ],
+
+  invalid: [
+    {
+      code: 'it("should fail", () => {});',
+      errors: [
+        {
+          message: 'Test has no assertions',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'test("should fail", () => {});',
+      errors: [
+        {
+          message: 'Test has no assertions',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'it("should fail", () => { somePromise.then(() => {}); });',
+      errors: [
+        {
+          message: 'Test has no assertions',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'test("should fail", () => { foo(true).toBe(true); })',
+      options: [{ assertFunctionNames: ['expect'] }],
+      errors: [
+        {
+          message: 'Test has no assertions',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'it("should also fail",() => expectSaga(mySaga).returns());',
+      options: [{ assertFunctionNames: ['expect'] }],
+      errors: [
+        {
+          message: 'Test has no assertions',
+          type: 'CallExpression',
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/lowercase-name.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/lowercase-name.test.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../lowercase-name');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+ruleTester.run('lowercase-name', rule, {
+  valid: [
+    'it()',
+    "it(' ', function () {})",
+    'it(" ", function () {})',
+    'it(` `, function () {})',
+    "it('foo', function () {})",
+    'it("foo", function () {})',
+    'it(`foo`, function () {})',
+    'it("<Foo/>", function () {})',
+    'it("123 foo", function () {})',
+    'it(42, function () {})',
+    'it(``)',
+    'test()',
+    "test('foo', function () {})",
+    'test("foo", function () {})',
+    'test(`foo`, function () {})',
+    'test("<Foo/>", function () {})',
+    'test("123 foo", function () {})',
+    'test("42", function () {})',
+    'test(``)',
+    'describe()',
+    "describe('foo', function () {})",
+    'describe("foo", function () {})',
+    'describe(`foo`, function () {})',
+    'describe("<Foo/>", function () {})',
+    'describe("123 foo", function () {})',
+    'describe("42", function () {})',
+    'describe(function () {})',
+    'describe(``)',
+  ],
+
+  invalid: [
+    {
+      code: "it('Foo', function () {})",
+      output: "it('foo', function () {})",
+      errors: [
+        {
+          message: '`it`s should begin with lowercase',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'it("Foo", function () {})',
+      output: 'it("foo", function () {})',
+      errors: [
+        {
+          message: '`it`s should begin with lowercase',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'it(`Foo`, function () {})',
+      output: 'it(`foo`, function () {})',
+      errors: [
+        {
+          message: '`it`s should begin with lowercase',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "test('Foo', function () {})",
+      output: "test('foo', function () {})",
+      errors: [
+        {
+          message: '`test`s should begin with lowercase',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'test("Foo", function () {})',
+      output: 'test("foo", function () {})',
+      errors: [
+        {
+          message: '`test`s should begin with lowercase',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'test(`Foo`, function () {})',
+      output: 'test(`foo`, function () {})',
+      errors: [
+        {
+          message: '`test`s should begin with lowercase',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "describe('Foo', function () {})",
+      output: "describe('foo', function () {})",
+      errors: [
+        {
+          message: '`describe`s should begin with lowercase',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'describe("Foo", function () {})',
+      output: 'describe("foo", function () {})',
+      errors: [
+        {
+          message: '`describe`s should begin with lowercase',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'describe(`Foo`, function () {})',
+      output: 'describe(`foo`, function () {})',
+      errors: [
+        {
+          message: '`describe`s should begin with lowercase',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'describe(`Some longer description`, function () {})',
+      output: 'describe(`some longer description`, function () {})',
+      errors: [
+        {
+          message: '`describe`s should begin with lowercase',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('lowercase-name with ignore=describe', rule, {
+  valid: [
+    {
+      code: "describe('Foo', function () {})",
+      options: [{ ignore: ['describe'] }],
+    },
+    {
+      code: 'describe("Foo", function () {})',
+      options: [{ ignore: ['describe'] }],
+    },
+    {
+      code: 'describe(`Foo`, function () {})',
+      options: [{ ignore: ['describe'] }],
+    },
+  ],
+  invalid: [],
+});
+
+ruleTester.run('lowercase-name with ignore=test', rule, {
+  valid: [
+    {
+      code: "test('Foo', function () {})",
+      options: [{ ignore: ['test'] }],
+    },
+    {
+      code: 'test("Foo", function () {})',
+      options: [{ ignore: ['test'] }],
+    },
+    {
+      code: 'test(`Foo`, function () {})',
+      options: [{ ignore: ['test'] }],
+    },
+  ],
+  invalid: [],
+});
+
+ruleTester.run('lowercase-name with ignore=it', rule, {
+  valid: [
+    {
+      code: "it('Foo', function () {})",
+      options: [{ ignore: ['it'] }],
+    },
+    {
+      code: 'it("Foo", function () {})',
+      options: [{ ignore: ['it'] }],
+    },
+    {
+      code: 'it(`Foo`, function () {})',
+      options: [{ ignore: ['it'] }],
+    },
+  ],
+  invalid: [],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-alias-methods.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-alias-methods.test.js
@@ -1,0 +1,194 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-alias-methods');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-alias-methods', rule, {
+  valid: [
+    'expect(a).toHaveBeenCalled()',
+    'expect(a).toHaveBeenCalledTimes()',
+    'expect(a).toHaveBeenCalledWith()',
+    'expect(a).toHaveBeenLastCalledWith()',
+    'expect(a).toHaveBeenNthCalledWith()',
+    'expect(a).toHaveReturned()',
+    'expect(a).toHaveReturnedTimes()',
+    'expect(a).toHaveReturnedWith()',
+    'expect(a).toHaveLastReturnedWith()',
+    'expect(a).toHaveNthReturnedWith()',
+    'expect(a).toThrow()',
+    'expect(a).rejects;',
+  ],
+
+  invalid: [
+    {
+      code: 'expect(a).toBeCalled()',
+      errors: [
+        {
+          message:
+            'Replace toBeCalled() with its canonical name of toHaveBeenCalled()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toHaveBeenCalled()',
+    },
+    {
+      code: 'expect(a).toBeCalledTimes()',
+      errors: [
+        {
+          message:
+            'Replace toBeCalledTimes() with its canonical name of toHaveBeenCalledTimes()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toHaveBeenCalledTimes()',
+    },
+    {
+      code: 'expect(a).toBeCalledWith()',
+      errors: [
+        {
+          message:
+            'Replace toBeCalledWith() with its canonical name of toHaveBeenCalledWith()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toHaveBeenCalledWith()',
+    },
+    {
+      code: 'expect(a).lastCalledWith()',
+      errors: [
+        {
+          message:
+            'Replace lastCalledWith() with its canonical name of toHaveBeenLastCalledWith()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toHaveBeenLastCalledWith()',
+    },
+    {
+      code: 'expect(a).nthCalledWith()',
+      errors: [
+        {
+          message:
+            'Replace nthCalledWith() with its canonical name of toHaveBeenNthCalledWith()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toHaveBeenNthCalledWith()',
+    },
+    {
+      code: 'expect(a).toReturn()',
+      errors: [
+        {
+          message:
+            'Replace toReturn() with its canonical name of toHaveReturned()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toHaveReturned()',
+    },
+    {
+      code: 'expect(a).toReturnTimes()',
+      errors: [
+        {
+          message:
+            'Replace toReturnTimes() with its canonical name of toHaveReturnedTimes()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toHaveReturnedTimes()',
+    },
+    {
+      code: 'expect(a).toReturnWith()',
+      errors: [
+        {
+          message:
+            'Replace toReturnWith() with its canonical name of toHaveReturnedWith()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toHaveReturnedWith()',
+    },
+    {
+      code: 'expect(a).lastReturnedWith()',
+      errors: [
+        {
+          message:
+            'Replace lastReturnedWith() with its canonical name of toHaveLastReturnedWith()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toHaveLastReturnedWith()',
+    },
+    {
+      code: 'expect(a).nthReturnedWith()',
+      errors: [
+        {
+          message:
+            'Replace nthReturnedWith() with its canonical name of toHaveNthReturnedWith()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toHaveNthReturnedWith()',
+    },
+    {
+      code: 'expect(a).toThrowError()',
+      errors: [
+        {
+          message:
+            'Replace toThrowError() with its canonical name of toThrow()',
+          column: 11,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toThrow()',
+    },
+    {
+      code: 'expect(a).resolves.toThrowError()',
+      errors: [
+        {
+          message:
+            'Replace toThrowError() with its canonical name of toThrow()',
+          column: 20,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).resolves.toThrow()',
+    },
+    {
+      code: 'expect(a).rejects.toThrowError()',
+      errors: [
+        {
+          message:
+            'Replace toThrowError() with its canonical name of toThrow()',
+          column: 19,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).rejects.toThrow()',
+    },
+    {
+      code: 'expect(a).not.toThrowError()',
+      errors: [
+        {
+          message:
+            'Replace toThrowError() with its canonical name of toThrow()',
+          column: 15,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).not.toThrow()',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-disabled-tests.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-disabled-tests.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-disabled-tests');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-disabled-tests', rule, {
+  valid: [
+    'describe("foo", function () {})',
+    'it("foo", function () {})',
+    'describe.only("foo", function () {})',
+    'it.only("foo", function () {})',
+    'test("foo", function () {})',
+    'test.only("foo", function () {})',
+    'var appliedSkip = describe.skip; appliedSkip.apply(describe)',
+    'var calledSkip = it.skip; calledSkip.call(it)',
+    '({ f: function () {} }).f()',
+    '(a || b).f()',
+    'itHappensToStartWithIt()',
+    'testSomething()',
+    [
+      'import { pending } from "actions"',
+      '',
+      'test("foo", () => {',
+      '  expect(pending()).toEqual({})',
+      '})',
+    ].join('\n'),
+    [
+      'const { pending } = require("actions")',
+      '',
+      'test("foo", () => {',
+      '  expect(pending()).toEqual({})',
+      '})',
+    ].join('\n'),
+    [
+      'test("foo", () => {',
+      '  const pending = getPending()',
+      '  expect(pending()).toEqual({})',
+      '})',
+    ].join('\n'),
+    [
+      'test("foo", () => {',
+      '  expect(pending()).toEqual({})',
+      '})',
+      '',
+      'function pending() {',
+      '  return {}',
+      '}',
+    ].join('\n'),
+  ],
+
+  invalid: [
+    {
+      code: 'describe.skip("foo", function () {})',
+      errors: [{ message: 'Skipped test suite', column: 1, line: 1 }],
+    },
+    {
+      code: 'describe["skip"]("foo", function () {})',
+      errors: [{ message: 'Skipped test suite', column: 1, line: 1 }],
+    },
+    {
+      code: 'it.skip("foo", function () {})',
+      errors: [{ message: 'Skipped test', column: 1, line: 1 }],
+    },
+    {
+      code: 'it["skip"]("foo", function () {})',
+      errors: [{ message: 'Skipped test', column: 1, line: 1 }],
+    },
+    {
+      code: 'test.skip("foo", function () {})',
+      errors: [{ message: 'Skipped test', column: 1, line: 1 }],
+    },
+    {
+      code: 'test["skip"]("foo", function () {})',
+      errors: [{ message: 'Skipped test', column: 1, line: 1 }],
+    },
+    {
+      code: 'xdescribe("foo", function () {})',
+      errors: [{ message: 'Disabled test suite', column: 1, line: 1 }],
+    },
+    {
+      code: 'xit("foo", function () {})',
+      errors: [{ message: 'Disabled test', column: 1, line: 1 }],
+    },
+    {
+      code: 'xtest("foo", function () {})',
+      errors: [{ message: 'Disabled test', column: 1, line: 1 }],
+    },
+    {
+      code: 'it("has title but no callback")',
+      errors: [
+        {
+          message: 'Test is missing function argument',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'test("has title but no callback")',
+      errors: [
+        {
+          message: 'Test is missing function argument',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'it("contains a call to pending", function () { pending() })',
+      errors: [
+        { message: 'Call to pending() within test', column: 48, line: 1 },
+      ],
+    },
+    {
+      code: 'pending();',
+      errors: [{ message: 'Call to pending()', column: 1, line: 1 }],
+    },
+    {
+      code: 'describe("contains a call to pending", function () { pending() })',
+      errors: [
+        {
+          message: 'Call to pending() within test suite',
+          column: 54,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-empty-title.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-empty-title.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-empty-title');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-empty-title', rule, {
+  valid: [
+    'someFn("", function () {})',
+    'describe(1, function () {})',
+    'describe("foo", function () {})',
+    'describe("foo", function () { it("bar", function () {}) })',
+    'test("foo", function () {})',
+    'test(`foo`, function () {})',
+    'test(`${foo}`, function () {})',
+    "it('foo', function () {})",
+    "xdescribe('foo', function () {})",
+    "xit('foo', function () {})",
+    "xtest('foo', function () {})",
+  ],
+  invalid: [
+    {
+      code: 'describe("", function () {})',
+      errors: [
+        {
+          message: rule.errorMessages.describe,
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: ["describe('foo', () => {", "it('', () => {})", '})'].join('\n'),
+      errors: [
+        {
+          message: rule.errorMessages.test,
+          column: 1,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: 'it("", function () {})',
+      errors: [
+        {
+          message: rule.errorMessages.test,
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'test("", function () {})',
+      errors: [
+        {
+          message: rule.errorMessages.test,
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'test(``, function () {})',
+      errors: [
+        {
+          message: rule.errorMessages.test,
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "xdescribe('', () => {})",
+      errors: [
+        {
+          message: rule.errorMessages.describe,
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "xit('', () => {})",
+      errors: [
+        {
+          message: rule.errorMessages.test,
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "xtest('', () => {})",
+      errors: [
+        {
+          message: rule.errorMessages.test,
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-focused-tests.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-focused-tests.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-focused-tests');
+
+const ruleTester = new RuleTester();
+const expectedErrorMessage = 'Unexpected focused test.';
+
+ruleTester.run('no-focused-tests', rule, {
+  valid: [
+    'describe()',
+    'it()',
+    'describe.skip()',
+    'it.skip()',
+    'test()',
+    'test.skip()',
+    'var appliedOnly = describe.only; appliedOnly.apply(describe)',
+    'var calledOnly = it.only; calledOnly.call(it)',
+  ],
+
+  invalid: [
+    {
+      code: 'describe.only()',
+      errors: [{ message: expectedErrorMessage, column: 10, line: 1 }],
+    },
+    {
+      code: 'describe.only.each()',
+      errors: [{ message: expectedErrorMessage, column: 10, line: 1 }],
+    },
+    {
+      code: 'describe["only"]()',
+      errors: [{ message: expectedErrorMessage, column: 10, line: 1 }],
+    },
+    {
+      code: 'it.only()',
+      errors: [{ message: expectedErrorMessage, column: 4, line: 1 }],
+    },
+    {
+      code: 'it.only.each()',
+      errors: [{ message: expectedErrorMessage, column: 4, line: 1 }],
+    },
+    {
+      code: 'it["only"]()',
+      errors: [{ message: expectedErrorMessage, column: 4, line: 1 }],
+    },
+    {
+      code: 'test.only()',
+      errors: [{ message: expectedErrorMessage, column: 6, line: 1 }],
+    },
+    {
+      code: 'test.only.each()',
+      errors: [{ message: expectedErrorMessage, column: 6, line: 1 }],
+    },
+    {
+      code: 'test["only"]()',
+      errors: [{ message: expectedErrorMessage, column: 6, line: 1 }],
+    },
+    {
+      code: 'fdescribe()',
+      errors: [{ message: expectedErrorMessage, column: 1, line: 1 }],
+    },
+    {
+      code: 'fit()',
+      errors: [{ message: expectedErrorMessage, column: 1, line: 1 }],
+    },
+    {
+      code: 'fit.each()',
+      errors: [{ message: expectedErrorMessage, column: 1, line: 1 }],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-hooks.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-hooks.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-hooks');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+ruleTester.run('no-hooks', rule, {
+  valid: [
+    'test("foo")',
+    'describe("foo", () => { it("bar") })',
+    'test("foo", () => { expect(subject.beforeEach()).toBe(true) })',
+    {
+      code: 'afterEach(() => {}); afterAll(() => {});',
+      options: [{ allow: ['afterEach', 'afterAll'] }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'beforeAll(() => {})',
+      errors: [{ message: "Unexpected 'beforeAll' hook" }],
+    },
+    {
+      code: 'beforeEach(() => {})',
+      errors: [{ message: "Unexpected 'beforeEach' hook" }],
+    },
+    {
+      code: 'afterAll(() => {})',
+      errors: [{ message: "Unexpected 'afterAll' hook" }],
+    },
+    {
+      code: 'afterEach(() => {})',
+      errors: [{ message: "Unexpected 'afterEach' hook" }],
+    },
+    {
+      code: 'beforeEach(() => {}); afterEach(() => { jest.resetModules() });',
+      options: [{ allow: ['afterEach'] }],
+      errors: [{ message: "Unexpected 'beforeEach' hook" }],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-identical-title.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-identical-title.test.js
@@ -1,0 +1,269 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-identical-title');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-identical-title', rule, {
+  valid: [
+    [
+      'describe("describe", function() {',
+      '   it("it", function() {});',
+      '});',
+    ].join('\n'),
+    ['describe();describe();'].join('\n'),
+    ['it();it();'].join('\n'),
+    [
+      'describe("describe1", function() {',
+      '   it("it1", function() {});',
+      '   it("it2", function() {});',
+      '});',
+    ].join('\n'),
+    ['it("it1", function() {});', 'it("it2", function() {});'].join('\n'),
+    ['it.only("it1", function() {});', 'it("it2", function() {});'].join('\n'),
+    ['it.only("it1", function() {});', 'it.only("it2", function() {});'].join(
+      '\n'
+    ),
+    ['describe("title", function() {});', 'it("title", function() {});'].join(
+      '\n'
+    ),
+    [
+      'describe("describe1", function() {',
+      '   it("it1", function() {});',
+      '   describe("describe2", function() {',
+      '       it("it1", function() {});',
+      '   });',
+      '});',
+    ].join('\n'),
+    [
+      'describe("describe1", function() {',
+      '   describe("describe2", function() {',
+      '       it("it1", function() {});',
+      '   });',
+      '   it("it1", function() {});',
+      '});',
+    ].join('\n'),
+    [
+      'describe("describe1", function() {',
+      '   describe("describe2", function() {});',
+      '});',
+    ].join('\n'),
+    [
+      'describe("describe1", function() {',
+      '   describe("describe2", function() {});',
+      '});',
+      'describe("describe2", function() {});',
+    ].join('\n'),
+    [
+      'describe("describe1", function() {});',
+      'describe("describe2", function() {});',
+    ].join('\n'),
+    ['it("it" + n, function() {});', 'it("it" + n, function() {});'].join('\n'),
+    {
+      code: [
+        'it(`it${n}`, function() {});',
+        'it(`it${n}`, function() {});',
+      ].join('\n'),
+      env: {
+        es6: true,
+      },
+    },
+    {
+      code: 'it(`${n}`, function() {});',
+      env: {
+        es6: true,
+      },
+    },
+    [
+      'describe("title " + foo, function() {',
+      '    describe("describe1", function() {});',
+      '});',
+      'describe("describe1", function() {});',
+    ].join('\n'),
+    [
+      'describe("describe1", function() {',
+      '    describe("describe2", function() {});',
+      '    describe("title " + foo, function() {',
+      '        describe("describe2", function() {});',
+      '    });',
+      '});',
+    ].join('\n'),
+    {
+      code: [
+        'describe("describe", () => {',
+        '    it(`testing ${someVar} with the same title`, () => {});',
+        '    it(`testing ${someVar} with the same title`, () => {});',
+        '});',
+      ].join('\n'),
+      env: {
+        es6: true,
+      },
+    },
+    {
+      code: ['it(`it1`, () => {});', 'it(`it2`, () => {});'].join('\n'),
+      env: {
+        es6: true,
+      },
+    },
+    {
+      code: [
+        'describe(`describe1`, () => {});',
+        'describe(`describe2`, () => {});',
+      ].join('\n'),
+      env: {
+        es6: true,
+      },
+    },
+  ],
+
+  invalid: [
+    {
+      code: [
+        'describe("describe1", function() {',
+        '   it("it1", function() {});',
+        '   it("it1", function() {});',
+        '});',
+      ].join('\n'),
+      errors: [
+        {
+          message:
+            'Test title is used multiple times in the same describe block.',
+          column: 4,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: ['it("it1", function() {});', 'it("it1", function() {});'].join(
+        '\n'
+      ),
+      errors: [
+        {
+          message:
+            'Test title is used multiple times in the same describe block.',
+          column: 1,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: [
+        'it.only("it1", function() {});',
+        'it("it1", function() {});',
+      ].join('\n'),
+      errors: [
+        {
+          message:
+            'Test title is used multiple times in the same describe block.',
+          column: 1,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: ['fit("it1", function() {});', 'it("it1", function() {});'].join(
+        '\n'
+      ),
+      errors: [
+        {
+          message:
+            'Test title is used multiple times in the same describe block.',
+          column: 1,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: [
+        'it.only("it1", function() {});',
+        'it.only("it1", function() {});',
+      ].join('\n'),
+      errors: [
+        {
+          message:
+            'Test title is used multiple times in the same describe block.',
+          column: 1,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: [
+        'describe("describe1", function() {});',
+        'describe("describe1", function() {});',
+      ].join('\n'),
+      errors: [
+        {
+          message:
+            'Describe block title is used multiple times in the same describe block.',
+          column: 1,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: [
+        'describe("describe1", function() {});',
+        'xdescribe("describe1", function() {});',
+      ].join('\n'),
+      errors: [
+        {
+          message:
+            'Describe block title is used multiple times in the same describe block.',
+          column: 1,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: [
+        'fdescribe("describe1", function() {});',
+        'describe("describe1", function() {});',
+      ].join('\n'),
+      errors: [
+        {
+          message:
+            'Describe block title is used multiple times in the same describe block.',
+          column: 1,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: [
+        'describe("describe1", function() {',
+        '   describe("describe2", function() {});',
+        '});',
+        'describe("describe1", function() {});',
+      ].join('\n'),
+      errors: [
+        {
+          message:
+            'Describe block title is used multiple times in the same describe block.',
+          column: 1,
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: [
+        'describe("describe", () => {',
+        '    it(`testing backticks with the same title`, () => {});',
+        '    it(`testing backticks with the same title`, () => {});',
+        '});',
+      ].join('\n'),
+      env: {
+        es6: true,
+      },
+      errors: [
+        {
+          message:
+            'Test title is used multiple times in the same describe block.',
+          column: 5,
+          line: 3,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-jasmine-globals.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-jasmine-globals.test.js
@@ -1,0 +1,228 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-jasmine-globals');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-jasmine-globals', rule, {
+  valid: [
+    'jest.spyOn()',
+    'jest.fn()',
+    'expect.extend()',
+    'expect.any()',
+    'it("foo", function () {})',
+    'test("foo", function () {})',
+    'foo()',
+    `require('foo')('bar')`,
+    'function callback(fail) { fail() }',
+    'var spyOn = require("actions"); spyOn("foo")',
+    'function callback(pending) { pending() }',
+  ],
+  invalid: [
+    {
+      code: 'spyOn(some, "object")',
+      errors: [
+        {
+          message: 'Illegal usage of global `spyOn`, prefer `jest.spyOn`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'spyOnProperty(some, "object")',
+      errors: [
+        {
+          message:
+            'Illegal usage of global `spyOnProperty`, prefer `jest.spyOn`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'fail()',
+      errors: [
+        {
+          message:
+            'Illegal usage of `fail`, prefer throwing an error, or the `done.fail` callback',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'pending()',
+      errors: [
+        {
+          message:
+            'Illegal usage of `pending`, prefer explicitly skipping a test using `test.skip`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;',
+      errors: [
+        {
+          message: 'Illegal usage of jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+      output: 'jest.setTimeout(5000);',
+    },
+    {
+      code: 'jasmine.addMatchers(matchers)',
+      errors: [
+        {
+          message:
+            'Illegal usage of `jasmine.addMatchers`, prefer `expect.extend`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.createSpy()',
+      errors: [
+        {
+          message: 'Illegal usage of `jasmine.createSpy`, prefer `jest.fn`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.any()',
+      errors: [
+        {
+          message: 'Illegal usage of `jasmine.any`, prefer `expect.any`',
+          column: 1,
+          line: 1,
+        },
+      ],
+      output: 'expect.any()',
+    },
+    {
+      code: 'jasmine.anything()',
+      errors: [
+        {
+          message:
+            'Illegal usage of `jasmine.anything`, prefer `expect.anything`',
+          column: 1,
+          line: 1,
+        },
+      ],
+      output: 'expect.anything()',
+    },
+    {
+      code: 'jasmine.arrayContaining()',
+      errors: [
+        {
+          message:
+            'Illegal usage of `jasmine.arrayContaining`, prefer `expect.arrayContaining`',
+          column: 1,
+          line: 1,
+        },
+      ],
+      output: 'expect.arrayContaining()',
+    },
+    {
+      code: 'jasmine.objectContaining()',
+      errors: [
+        {
+          message:
+            'Illegal usage of `jasmine.objectContaining`, prefer `expect.objectContaining`',
+          column: 1,
+          line: 1,
+        },
+      ],
+      output: 'expect.objectContaining()',
+    },
+    {
+      code: 'jasmine.stringMatching()',
+      errors: [
+        {
+          message:
+            'Illegal usage of `jasmine.stringMatching`, prefer `expect.stringMatching`',
+          column: 1,
+          line: 1,
+        },
+      ],
+      output: 'expect.stringMatching()',
+    },
+    {
+      code: 'jasmine.getEnv()',
+      errors: [
+        {
+          message: 'Illegal usage of jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.empty()',
+      errors: [
+        {
+          message: 'Illegal usage of jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.falsy()',
+      errors: [
+        {
+          message: 'Illegal usage of jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.truthy()',
+      errors: [
+        {
+          message: 'Illegal usage of jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.arrayWithExactContents()',
+      errors: [
+        {
+          message: 'Illegal usage of jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.clock()',
+      errors: [
+        {
+          message: 'Illegal usage of jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH = 42',
+      errors: [
+        {
+          message: 'Illegal usage of jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-jest-import.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-jest-import.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const rule = require('../no-jest-import.js');
+const { RuleTester } = require('eslint');
+const ruleTester = new RuleTester();
+const message = `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`;
+
+ruleTester.run('no-jest-import', rule, {
+  valid: [
+    {
+      code: 'import something from "something"',
+      parserOptions: { sourceType: 'module' },
+    },
+    'require("somethingElse")',
+    'require()',
+    'entirelyDifferent(fn)',
+  ],
+  invalid: [
+    {
+      code: 'require("jest")',
+      errors: [
+        {
+          endColumn: 15,
+          column: 9,
+          message,
+        },
+      ],
+    },
+    {
+      code: 'import jest from "jest"',
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          endColumn: 24,
+          column: 1,
+          message,
+        },
+      ],
+    },
+    {
+      code: 'var jest = require("jest")',
+      errors: [
+        {
+          endColumn: 26,
+          column: 20,
+          message,
+        },
+      ],
+    },
+    {
+      code: 'import {jest as test} from "jest"',
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          endColumn: 34,
+          column: 1,
+          message,
+        },
+      ],
+    },
+    {
+      code: 'const jest = require("jest")',
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          endColumn: 28,
+          column: 22,
+          message,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-large-snapshots.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-large-snapshots.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-large-snapshots');
+const noLargeSnapshots = rule.create;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2015,
+  },
+});
+
+ruleTester.run('no-large-snapshots', rule, {
+  valid: [
+    {
+      filename: 'mock.js',
+      code: `expect(something).toMatchInlineSnapshot(\`\n${'line\n'.repeat(
+        2
+      )}\`);`,
+    },
+    {
+      filename: 'mock.js',
+      code: `expect(something).toThrowErrorMatchingInlineSnapshot(\`\n${'line\n'.repeat(
+        2
+      )}\`);`,
+    },
+  ],
+  invalid: [
+    {
+      filename: 'mock.js',
+      code: `expect(something).toMatchInlineSnapshot(\`\n${'line\n'.repeat(
+        50
+      )}\`);`,
+      errors: [
+        {
+          message:
+            'Expected Jest snapshot to be smaller than 50 lines but was 51 lines long',
+        },
+      ],
+    },
+    {
+      filename: 'mock.js',
+      code: `expect(something).toThrowErrorMatchingInlineSnapshot(\`\n${'line\n'.repeat(
+        50
+      )}\`);`,
+      errors: [
+        {
+          message:
+            'Expected Jest snapshot to be smaller than 50 lines but was 51 lines long',
+        },
+      ],
+    },
+  ],
+});
+
+// was not able to use https://eslint.org/docs/developer-guide/nodejs-api#ruletester for these because there is no way to configure RuleTester to run non .js files
+describe('no-large-snapshots', () => {
+  it('should return an empty object for non snapshot files', () => {
+    const mockContext = {
+      getFilename: () => 'mock-component.jsx',
+      options: [],
+    };
+    const result = noLargeSnapshots(mockContext);
+
+    expect(result).toEqual({});
+  });
+
+  it('should return an object with an ExpressionStatement function for snapshot files', () => {
+    const mockContext = {
+      getFilename: () => 'mock-component.jsx.snap',
+      options: [],
+    };
+
+    const result = noLargeSnapshots(mockContext);
+
+    expect(result).toMatchObject({
+      ExpressionStatement: expect.any(Function),
+    });
+  });
+
+  describe('ExpressionStatement function', () => {
+    it('should report if node has more than 50 lines of code and no sizeThreshold option is passed', () => {
+      const mockReport = jest.fn();
+      const mockContext = {
+        getFilename: () => 'mock-component.jsx.snap',
+        options: [],
+        report: mockReport,
+      };
+      const mockNode = {
+        loc: {
+          start: {
+            line: 1,
+          },
+          end: {
+            line: 53,
+          },
+        },
+      };
+      noLargeSnapshots(mockContext).ExpressionStatement(mockNode);
+
+      expect(mockReport).toHaveBeenCalledTimes(1);
+      expect(mockReport.mock.calls[0]).toMatchSnapshot();
+    });
+
+    it('should report if node has more lines of code than number given in sizeThreshold option', () => {
+      const mockReport = jest.fn();
+      const mockContext = {
+        getFilename: () => 'mock-component.jsx.snap',
+        options: [{ maxSize: 70 }],
+        report: mockReport,
+      };
+      const mockNode = {
+        loc: {
+          start: {
+            line: 20,
+          },
+          end: {
+            line: 103,
+          },
+        },
+      };
+      noLargeSnapshots(mockContext).ExpressionStatement(mockNode);
+
+      expect(mockReport).toHaveBeenCalledTimes(1);
+      expect(mockReport.mock.calls[0]).toMatchSnapshot();
+    });
+
+    it('should report if maxSize is zero', () => {
+      const mockReport = jest.fn();
+      const mockContext = {
+        getFilename: () => 'mock-component.jsx.snap',
+        options: [{ maxSize: 0 }],
+        report: mockReport,
+      };
+      const mockNode = {
+        loc: {
+          start: {
+            line: 1,
+          },
+          end: {
+            line: 2,
+          },
+        },
+      };
+      noLargeSnapshots(mockContext).ExpressionStatement(mockNode);
+
+      expect(mockReport).toHaveBeenCalledTimes(1);
+      expect(mockReport.mock.calls[0]).toMatchSnapshot();
+    });
+
+    it('should not report if node has fewer lines of code than limit', () => {
+      const mockReport = jest.fn();
+      const mockContext = {
+        getFilename: () => 'mock-component.jsx.snap',
+        options: [],
+        report: mockReport,
+      };
+      const mockNode = {
+        loc: {
+          start: {
+            line: 1,
+          },
+          end: {
+            line: 18,
+          },
+        },
+      };
+      noLargeSnapshots(mockContext).ExpressionStatement(mockNode);
+
+      expect(mockReport).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-mocks-import.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-mocks-import.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const rule = require('../no-mocks-import.js');
+const { RuleTester } = require('eslint');
+const ruleTester = new RuleTester();
+const message = `Mocks should not be manually imported from a __mocks__ directory. Instead use jest.mock and import from the original module path.`;
+
+ruleTester.run('no-mocks-import', rule, {
+  valid: [
+    {
+      code: 'import something from "something"',
+      parserOptions: { sourceType: 'module' },
+    },
+    'require("somethingElse")',
+    'require("./__mocks__.js")',
+    'require("./__mocks__x")',
+    'require("./__mocks__x/x")',
+    'require("./x__mocks__")',
+    'require("./x__mocks__/x")',
+    'require()',
+    'var path = "./__mocks__.js"; require(path)',
+    'entirelyDifferent(fn)',
+  ],
+  invalid: [
+    {
+      code: 'require("./__mocks__")',
+      errors: [
+        {
+          endColumn: 22,
+          column: 9,
+          message,
+        },
+      ],
+    },
+    {
+      code: 'require("./__mocks__/")',
+      errors: [
+        {
+          endColumn: 23,
+          column: 9,
+          message,
+        },
+      ],
+    },
+    {
+      code: 'require("./__mocks__/index")',
+      errors: [
+        {
+          endColumn: 28,
+          column: 9,
+          message,
+        },
+      ],
+    },
+    {
+      code: 'require("__mocks__")',
+      errors: [
+        {
+          endColumn: 20,
+          column: 9,
+          message,
+        },
+      ],
+    },
+    {
+      code: 'require("__mocks__/")',
+      errors: [
+        {
+          endColumn: 21,
+          column: 9,
+          message,
+        },
+      ],
+    },
+    {
+      code: 'require("__mocks__/index")',
+      errors: [
+        {
+          endColumn: 26,
+          column: 9,
+          message,
+        },
+      ],
+    },
+    {
+      code: 'import thing from "./__mocks__/index"',
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          endColumn: 38,
+          column: 1,
+          message,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-test-callback.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-test-callback.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-test-callback');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8,
+  },
+});
+
+ruleTester.run('no-test-callback', rule, {
+  valid: [
+    'test("something", () => {})',
+    'test("something", async () => {})',
+    'test("something", function() {})',
+    'test("something", async function () {})',
+    'test("something", someArg)',
+  ],
+  invalid: [
+    {
+      code: 'test("something", done => {done();})',
+      errors: [
+        {
+          message: 'Illegal usage of test callback',
+          line: 1,
+          column: 19,
+        },
+      ],
+      output:
+        'test("something", () => {return new Promise(done => {done();})})',
+    },
+    {
+      code: 'test("something", (done) => {done();})',
+      errors: [
+        {
+          message: 'Illegal usage of test callback',
+          line: 1,
+          column: 20,
+        },
+      ],
+      output:
+        'test("something", () => {return new Promise((done) => {done();})})',
+    },
+    {
+      code: 'test("something", done => done())',
+      errors: [
+        {
+          message: 'Illegal usage of test callback',
+          line: 1,
+          column: 19,
+        },
+      ],
+      output: 'test("something", () => new Promise(done => done()))',
+    },
+    {
+      code: 'test("something", (done) => done())',
+      errors: [
+        {
+          message: 'Illegal usage of test callback',
+          line: 1,
+          column: 20,
+        },
+      ],
+      output: 'test("something", () => new Promise((done) => done()))',
+    },
+    {
+      code: 'test("something", function(done) {done();})',
+      errors: [
+        {
+          message: 'Illegal usage of test callback',
+          line: 1,
+          column: 28,
+        },
+      ],
+      output:
+        'test("something", function() {return new Promise((done) => {done();})})',
+    },
+    {
+      code: 'test("something", function (done) {done();})',
+      errors: [
+        {
+          message: 'Illegal usage of test callback',
+          line: 1,
+          column: 29,
+        },
+      ],
+      output:
+        'test("something", function () {return new Promise((done) => {done();})})',
+    },
+    {
+      code: 'test("something", async done => {done();})',
+      errors: [
+        {
+          message: 'Illegal usage of test callback',
+          line: 1,
+          column: 25,
+        },
+      ],
+      output:
+        'test("something", async () => {await new Promise(done => {done();})})',
+    },
+    {
+      code: 'test("something", async done => done())',
+      errors: [
+        {
+          message: 'Illegal usage of test callback',
+          line: 1,
+          column: 25,
+        },
+      ],
+      output: 'test("something", async () => new Promise(done => done()))',
+    },
+    {
+      code: 'test("something", async function (done) {done();})',
+      errors: [
+        {
+          message: 'Illegal usage of test callback',
+          line: 1,
+          column: 35,
+        },
+      ],
+      output:
+        'test("something", async function () {await new Promise((done) => {done();})})',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-test-prefixes.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-test-prefixes.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-test-prefixes');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-test-prefixes', rule, {
+  valid: [
+    'describe("foo", function () {})',
+    'it("foo", function () {})',
+    'test("foo", function () {})',
+    'describe.only("foo", function () {})',
+    'it.only("foo", function () {})',
+    'test.only("foo", function () {})',
+    'describe.skip("foo", function () {})',
+    'it.skip("foo", function () {})',
+    'test.skip("foo", function () {})',
+    'foo()',
+  ],
+  invalid: [
+    {
+      code: 'fdescribe("foo", function () {})',
+      errors: [{ message: 'Use "describe.only" instead', column: 1, line: 1 }],
+      output: 'describe.only("foo", function () {})',
+    },
+    {
+      code: 'fit("foo", function () {})',
+      errors: [{ message: 'Use "it.only" instead', column: 1, line: 1 }],
+      output: 'it.only("foo", function () {})',
+    },
+    {
+      code: 'xdescribe("foo", function () {})',
+      errors: [{ message: 'Use "describe.skip" instead', column: 1, line: 1 }],
+      output: 'describe.skip("foo", function () {})',
+    },
+    {
+      code: 'xit("foo", function () {})',
+      errors: [{ message: 'Use "it.skip" instead', column: 1, line: 1 }],
+      output: 'it.skip("foo", function () {})',
+    },
+    {
+      code: 'xtest("foo", function () {})',
+      errors: [{ message: 'Use "test.skip" instead', column: 1, line: 1 }],
+      output: 'test.skip("foo", function () {})',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-test-return-statement.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-test-return-statement.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-test-return-statement');
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+
+ruleTester.run('no-test-prefixes', rule, {
+  valid: [
+    'it("noop", function () {});',
+    'test("noop", () => {});',
+    'test("one", () => expect(1).toBe(1));',
+    'test("empty")',
+    `
+    test("one", () => {
+      expect(1).toBe(1);
+    });
+    `,
+    `
+    it("one", function () {
+      expect(1).toBe(1);
+    });
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+      test("one", () => {
+        return expect(1).toBe(1);
+      });
+      `,
+      errors: [
+        {
+          message: 'Jest tests should not return a value.',
+          column: 9,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+      it("one", function () {
+        return expect(1).toBe(1);
+      });
+      `,
+      errors: [
+        {
+          message: 'Jest tests should not return a value.',
+          column: 9,
+          line: 3,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/no-truthy-falsy.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/no-truthy-falsy.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-truthy-falsy');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-truthy-falsy', rule, {
+  valid: [
+    'expect(true).toBe(true);',
+    'expect(false).toBe(false);',
+    'expect("anything").toBe(true);',
+    'expect("anything").toEqual(false);',
+    'expect("anything").not.toBe(true);',
+    'expect("anything").not.toEqual(true);',
+    'expect(Promise.resolve({})).resolves.toBe(true);',
+    'expect(Promise.reject({})).rejects.toBe(true);',
+  ],
+
+  invalid: [
+    {
+      code: 'expect(true).toBeTruthy();',
+      errors: [
+        {
+          message: 'Avoid toBeTruthy',
+          column: 14,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(false).not.toBeTruthy();',
+      errors: [
+        {
+          message: 'Avoid toBeTruthy',
+          column: 19,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(Promise.resolve({})).resolves.toBeTruthy()',
+      errors: [
+        {
+          message: 'Avoid toBeTruthy',
+          column: 38,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(Promise.resolve({})).rejects.toBeTruthy()',
+      errors: [
+        {
+          message: 'Avoid toBeTruthy',
+          column: 37,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(false).toBeFalsy();',
+      errors: [
+        {
+          message: 'Avoid toBeFalsy',
+          column: 15,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(true).not.toBeFalsy();',
+      errors: [
+        {
+          message: 'Avoid toBeFalsy',
+          column: 18,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(Promise.resolve({})).resolves.toBeFalsy()',
+      errors: [
+        {
+          message: 'Avoid toBeFalsy',
+          column: 38,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(Promise.resolve({})).rejects.toBeFalsy()',
+      errors: [
+        {
+          message: 'Avoid toBeFalsy',
+          column: 37,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/prefer-called-with.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/prefer-called-with.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../prefer-called-with');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-called-with', rule, {
+  valid: [
+    'expect(fn).toBeCalledWith();',
+    'expect(fn).toHaveBeenCalledWith();',
+    'expect(fn).toBeCalledWith(expect.anything());',
+    'expect(fn).toHaveBeenCalledWith(expect.anything());',
+    'expect(fn).not.toBeCalled();',
+    'expect(fn).not.toHaveBeenCalled();',
+    'expect(fn).not.toBeCalledWith();',
+    'expect(fn).not.toHaveBeenCalledWith();',
+    'expect(fn).toBeCalledTimes(0);',
+    'expect(fn).toHaveBeenCalledTimes(0);',
+  ],
+
+  invalid: [
+    {
+      code: 'expect(fn).toBeCalled();',
+      errors: [
+        {
+          message: 'Prefer toBeCalledWith(/* expected args */)',
+          column: 12,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(fn).toHaveBeenCalled();',
+      errors: [
+        {
+          message: 'Prefer toHaveBeenCalledWith(/* expected args */)',
+          column: 12,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/prefer-expect-assertions.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/prefer-expect-assertions.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../prefer-expect-assertions');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+const expectedMsg =
+  'Every test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression';
+
+ruleTester.run('prefer-expect-assertions', rule, {
+  invalid: [
+    {
+      code: 'it("it1", () => {})',
+      errors: [
+        {
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: 'it("it1", () => { foo()})',
+      errors: [
+        {
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code:
+        'it("it1", function() {' +
+        '\n\t\t\tsomeFunctionToDo();' +
+        '\n\t\t\tsomeFunctionToDo2();\n' +
+        '\t\t\t})',
+      errors: [
+        {
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: 'it("it1", function() {var a = 2;})',
+      errors: [
+        {
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: 'it("it1", function() {expect.assertions();})',
+      errors: [
+        {
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: 'it("it1", function() {expect.assertions(1,2);})',
+      errors: [
+        {
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: 'it("it1", function() {expect.assertions("1");})',
+      errors: [
+        {
+          message: expectedMsg,
+        },
+      ],
+    },
+  ],
+
+  valid: [
+    {
+      code: 'test("it1", () => {expect.assertions(0);})',
+    },
+    'test("it1", function() {expect.assertions(0);})',
+    'test("it1", function() {expect.hasAssertions();})',
+    'it("it1", function() {expect.assertions(0);})',
+    'it("it1", function() {\n\t\t\texpect.assertions(1);' +
+      '\n\t\t\texpect(someValue).toBe(true)\n' +
+      '\t\t\t})',
+    'test("it1")',
+    'itHappensToStartWithIt("foo", function() {})',
+    'testSomething("bar", function() {})',
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/prefer-inline-snapshots.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/prefer-inline-snapshots.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../prefer-inline-snapshots');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-inline-snapshots', rule, {
+  valid: [
+    'expect(something).toMatchInlineSnapshot();',
+    'expect(something).toThrowErrorMatchingInlineSnapshot();',
+  ],
+  invalid: [
+    {
+      code: 'expect(something).toMatchSnapshot();',
+      errors: [
+        {
+          message: 'Use toMatchInlineSnapshot() instead',
+          column: 19,
+          line: 1,
+        },
+      ],
+      output: 'expect(something).toMatchInlineSnapshot();',
+    },
+    {
+      code: 'expect(something).toThrowErrorMatchingSnapshot();',
+      errors: [
+        {
+          message: 'Use toThrowErrorMatchingInlineSnapshot() instead',
+          column: 19,
+          line: 1,
+        },
+      ],
+      output: 'expect(something).toThrowErrorMatchingInlineSnapshot();',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/prefer-spy-on.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/prefer-spy-on.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../prefer-spy-on');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+ruleTester.run('prefer-spy-on', rule, {
+  valid: [
+    'Date.now = () => 10',
+    'window.fetch = jest.fn',
+    'Date.now = fn()',
+    'obj.mock = jest.something()',
+    'const mock = jest.fn()',
+    'mock = jest.fn()',
+    'const mockObj = { mock: jest.fn() }',
+    'mockObj = { mock: jest.fn() }',
+    'window[`${name}`] = jest[`fn${expression}`]()',
+  ],
+  invalid: [
+    {
+      code: 'obj.a = jest.fn(); const test = 10;',
+      errors: [
+        {
+          message: 'Use jest.spyOn() instead.',
+          type: 'AssignmentExpression',
+        },
+      ],
+      output: "jest.spyOn(obj, 'a'); const test = 10;",
+    },
+    {
+      code: "Date['now'] = jest['fn']()",
+      errors: [
+        {
+          message: 'Use jest.spyOn() instead.',
+          type: 'AssignmentExpression',
+        },
+      ],
+      output: "jest.spyOn(Date, 'now')",
+    },
+    {
+      code: 'window[`${name}`] = jest[`fn`]()',
+      errors: [
+        {
+          message: 'Use jest.spyOn() instead.',
+          type: 'AssignmentExpression',
+        },
+      ],
+      output: 'jest.spyOn(window, `${name}`)',
+    },
+    {
+      code: "obj['prop' + 1] = jest['fn']()",
+      errors: [
+        {
+          message: 'Use jest.spyOn() instead.',
+          type: 'AssignmentExpression',
+        },
+      ],
+      output: "jest.spyOn(obj, 'prop' + 1)",
+    },
+    {
+      code: 'obj.one.two = jest.fn(); const test = 10;',
+      errors: [
+        {
+          message: 'Use jest.spyOn() instead.',
+          type: 'AssignmentExpression',
+        },
+      ],
+      output: "jest.spyOn(obj.one, 'two'); const test = 10;",
+    },
+    {
+      code: 'obj.a = jest.fn(() => 10)',
+      errors: [
+        {
+          message: 'Use jest.spyOn() instead.',
+          type: 'AssignmentExpression',
+        },
+      ],
+      output: "jest.spyOn(obj, 'a').mockImplementation(() => 10)",
+    },
+    {
+      code:
+        "obj.a.b = jest.fn(() => ({})).mockReturnValue('default').mockReturnValueOnce('first call'); test();",
+      errors: [
+        {
+          message: 'Use jest.spyOn() instead.',
+          type: 'AssignmentExpression',
+        },
+      ],
+      output:
+        "jest.spyOn(obj.a, 'b').mockImplementation(() => ({})).mockReturnValue('default').mockReturnValueOnce('first call'); test();",
+    },
+    {
+      code: 'window.fetch = jest.fn(() => ({})).one.two().three().four',
+      errors: [
+        {
+          message: 'Use jest.spyOn() instead.',
+          type: 'AssignmentExpression',
+        },
+      ],
+      output:
+        "jest.spyOn(window, 'fetch').mockImplementation(() => ({})).one.two().three().four",
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/prefer-strict-equal.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/prefer-strict-equal.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../prefer-strict-equal');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-strict-equal', rule, {
+  valid: [
+    'expect(something).toStrictEqual(somethingElse);',
+    "a().toEqual('b')",
+  ],
+  invalid: [
+    {
+      code: 'expect(something).toEqual(somethingElse);',
+      errors: [
+        {
+          message: 'Use toStrictEqual() instead',
+          column: 19,
+          line: 1,
+        },
+      ],
+      output: 'expect(something).toStrictEqual(somethingElse);',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/prefer-to-be-null.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/prefer-to-be-null.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../prefer-to-be-null');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-to-be-null', rule, {
+  valid: [
+    'expect(null).toBeNull();',
+    'expect(null).toEqual();',
+    'expect(null).not.toBeNull();',
+    'expect(null).not.toEqual();',
+    'expect(null).toBe(undefined);',
+    'expect(null).not.toBe(undefined);',
+    'expect(null).toBe();',
+    'expect(null).toMatchSnapshot();',
+    'expect("a string").toMatchSnapshot(null);',
+    'expect("a string").not.toMatchSnapshot();',
+    "expect(something).toEqual('a string');",
+    'expect(null).toBe',
+  ],
+
+  invalid: [
+    {
+      code: 'expect(null).toBe(null);',
+      errors: [
+        {
+          message: 'Use toBeNull() instead',
+          column: 14,
+          line: 1,
+        },
+      ],
+      output: 'expect(null).toBeNull();',
+    },
+    {
+      code: 'expect(null).toEqual(null);',
+      errors: [
+        {
+          message: 'Use toBeNull() instead',
+          column: 14,
+          line: 1,
+        },
+      ],
+      output: 'expect(null).toBeNull();',
+    },
+    {
+      code: 'expect("a string").not.toBe(null);',
+      errors: [
+        {
+          message: 'Use toBeNull() instead',
+          column: 24,
+          line: 1,
+        },
+      ],
+      output: 'expect("a string").not.toBeNull();',
+    },
+    {
+      code: 'expect("a string").not.toEqual(null);',
+      errors: [
+        {
+          message: 'Use toBeNull() instead',
+          column: 24,
+          line: 1,
+        },
+      ],
+      output: 'expect("a string").not.toBeNull();',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/prefer-to-be-undefined.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/prefer-to-be-undefined.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../prefer-to-be-undefined');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-to-be-undefined', rule, {
+  valid: [
+    'expect(undefined).toBeUndefined();',
+    'expect(true).not.toBeUndefined();',
+    'expect({}).toEqual({});',
+    'expect(null).toEqual(null);',
+    'expect(something).toBe(somethingElse)',
+    'expect(something).toEqual(somethingElse)',
+    'expect(something).not.toBe(somethingElse)',
+    'expect(something).not.toEqual(somethingElse)',
+    'expect(undefined).toBe',
+  ],
+
+  invalid: [
+    {
+      code: 'expect(undefined).toBe(undefined);',
+      errors: [
+        {
+          message: 'Use toBeUndefined() instead',
+          column: 19,
+          line: 1,
+        },
+      ],
+      output: 'expect(undefined).toBeUndefined();',
+    },
+    {
+      code: 'expect(undefined).toEqual(undefined);',
+      errors: [
+        {
+          message: 'Use toBeUndefined() instead',
+          column: 19,
+          line: 1,
+        },
+      ],
+      output: 'expect(undefined).toBeUndefined();',
+    },
+    {
+      code: 'expect("a string").not.toBe(undefined);',
+      errors: [
+        {
+          message: 'Use toBeUndefined() instead',
+          column: 24,
+          line: 1,
+        },
+      ],
+      output: 'expect("a string").not.toBeUndefined();',
+    },
+    {
+      code: 'expect("a string").not.toEqual(undefined);',
+      errors: [
+        {
+          message: 'Use toBeUndefined() instead',
+          column: 24,
+          line: 1,
+        },
+      ],
+      output: 'expect("a string").not.toBeUndefined();',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/prefer-to-contain.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/prefer-to-contain.test.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../prefer-to-contain');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-to-contain', rule, {
+  valid: [
+    'expect(a).toContain(b);',
+    "expect(a.name).toBe('b');",
+    'expect(a).toBe(true);',
+    `expect(a).toEqual(b)`,
+    `expect(a.test(c)).toEqual(b)`,
+    `expect(a.includes(b)).toEqual()`,
+    `expect(a.includes(b)).toEqual("test")`,
+    `expect(a.includes(b)).toBe("test")`,
+    `expect(a.includes()).toEqual()`,
+    `expect(a.includes()).toEqual(true)`,
+    `expect(a.includes(b,c)).toBe(true)`,
+    `expect([{a:1}]).toContain({a:1})`,
+    `expect([1].includes(1)).toEqual`,
+    `expect([1].includes).toEqual`,
+    `expect([1].includes).not`,
+    `expect(a.test(b)).resolves.toEqual(true)`,
+    `expect(a.test(b)).resolves.not.toEqual(true)`,
+    `expect(a).not.toContain(b)`,
+  ],
+  invalid: [
+    {
+      code: 'expect(a.includes(b)).toEqual(true);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 23,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toContain(b);',
+    },
+    {
+      code: 'expect(a.includes(b)).toEqual(false);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 23,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).not.toContain(b);',
+    },
+    {
+      code: 'expect(a.includes(b)).not.toEqual(false);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 23,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toContain(b);',
+    },
+    {
+      code: 'expect(a.includes(b)).not.toEqual(true);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 23,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).not.toContain(b);',
+    },
+    {
+      code: 'expect(a.includes(b)).toBe(true);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 23,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toContain(b);',
+    },
+    {
+      code: 'expect(a.includes(b)).toBe(false);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 23,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).not.toContain(b);',
+    },
+    {
+      code: 'expect(a.includes(b)).not.toBe(false);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 23,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).toContain(b);',
+    },
+    {
+      code: 'expect(a.includes(b)).not.toBe(true);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 23,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).not.toContain(b);',
+    },
+    {
+      code: 'expect(a.test(t).includes(b.test(p))).toEqual(true);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 39,
+          line: 1,
+        },
+      ],
+      output: 'expect(a.test(t)).toContain(b.test(p));',
+    },
+    {
+      code: 'expect(a.test(t).includes(b.test(p))).toEqual(false);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 39,
+          line: 1,
+        },
+      ],
+      output: 'expect(a.test(t)).not.toContain(b.test(p));',
+    },
+    {
+      code: 'expect(a.test(t).includes(b.test(p))).not.toEqual(true);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 39,
+          line: 1,
+        },
+      ],
+      output: 'expect(a.test(t)).not.toContain(b.test(p));',
+    },
+    {
+      code: 'expect(a.test(t).includes(b.test(p))).not.toEqual(false);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 39,
+          line: 1,
+        },
+      ],
+      output: 'expect(a.test(t)).toContain(b.test(p));',
+    },
+    {
+      code: 'expect([{a:1}].includes({a:1})).toBe(true);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 33,
+          line: 1,
+        },
+      ],
+      output: 'expect([{a:1}]).toContain({a:1});',
+    },
+    {
+      code: 'expect([{a:1}].includes({a:1})).toBe(false);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 33,
+          line: 1,
+        },
+      ],
+      output: 'expect([{a:1}]).not.toContain({a:1});',
+    },
+    {
+      code: 'expect([{a:1}].includes({a:1})).not.toBe(true);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 33,
+          line: 1,
+        },
+      ],
+      output: 'expect([{a:1}]).not.toContain({a:1});',
+    },
+    {
+      code: 'expect([{a:1}].includes({a:1})).not.toBe(false);',
+      errors: [
+        {
+          message: 'Use toContain() instead',
+          column: 33,
+          line: 1,
+        },
+      ],
+      output: 'expect([{a:1}]).toContain({a:1});',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/prefer-to-have-length.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/prefer-to-have-length.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../prefer-to-have-length');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-to-have-length', rule, {
+  valid: [
+    'expect(files).toHaveLength(1);',
+    "expect(files.name).toBe('file');",
+    'expect(result).toBe(true);',
+    `expect(user.getUserName(5)).resolves.toEqual('Paul')`,
+    `expect(user.getUserName(5)).rejects.toEqual('Paul')`,
+  ],
+
+  invalid: [
+    {
+      code: 'expect(files.length).toBe(1);',
+      errors: [
+        {
+          message: 'Use toHaveLength() instead',
+          column: 22,
+          line: 1,
+        },
+      ],
+      output: 'expect(files).toHaveLength(1);',
+    },
+    {
+      code: 'expect(files.length).toEqual(1);',
+      errors: [
+        {
+          message: 'Use toHaveLength() instead',
+          column: 22,
+          line: 1,
+        },
+      ],
+      output: 'expect(files).toHaveLength(1);',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/prefer-todo.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/prefer-todo.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../prefer-todo');
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2015 },
+});
+
+ruleTester.run('prefer-todo', rule, {
+  valid: [
+    'test.todo("i need to write this test");',
+    'test(obj)',
+    'fit("foo")',
+    'xit("foo")',
+    'test("stub", () => expect(1).toBe(1));',
+    `
+      supportsDone && params.length < test.length
+        ? done => test(...params, done)
+        : () => test(...params);
+    `,
+  ],
+  invalid: [
+    {
+      code: `test("i need to write this test");`,
+      errors: [
+        { message: 'Prefer todo test case over unimplemented test case' },
+      ],
+      output: 'test.todo("i need to write this test");',
+    },
+    {
+      code: 'test(`i need to write this test`);',
+      errors: [
+        { message: 'Prefer todo test case over unimplemented test case' },
+      ],
+      output: 'test.todo(`i need to write this test`);',
+    },
+    {
+      code: 'it("foo", function () {})',
+      errors: ['Prefer todo test case over empty test case'],
+      output: 'it.todo("foo")',
+    },
+    {
+      code: 'it("foo", () => {})',
+      errors: ['Prefer todo test case over empty test case'],
+      output: 'it.todo("foo")',
+    },
+    {
+      code: `test.skip("i need to write this test", () => {});`,
+      errors: ['Prefer todo test case over empty test case'],
+      output: 'test.todo("i need to write this test");',
+    },
+    {
+      code: `test.skip("i need to write this test", function() {});`,
+      errors: ['Prefer todo test case over empty test case'],
+      output: 'test.todo("i need to write this test");',
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/require-tothrow-message.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/require-tothrow-message.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../require-tothrow-message');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+ruleTester.run('require-tothrow-message', rule, {
+  valid: [
+    // String
+    "expect(() => { throw new Error('a'); }).toThrow('a');",
+    "expect(() => { throw new Error('a'); }).toThrowError('a');",
+
+    // Template literal
+    "const a = 'a'; expect(() => { throw new Error('a'); }).toThrow(`${a}`);",
+
+    // Regex
+    "expect(() => { throw new Error('a'); }).toThrow(/^a$/);",
+
+    // Function
+    "expect(() => { throw new Error('a'); })" +
+      ".toThrow((() => { return 'a'; })());",
+
+    // Allow no message for `not`.
+    "expect(() => { throw new Error('a'); }).not.toThrow();",
+  ],
+
+  invalid: [
+    // Empty toThrow
+    {
+      code: "expect(() => { throw new Error('a'); }).toThrow();",
+      errors: [
+        { message: 'Add an error message to toThrow()', column: 41, line: 1 },
+      ],
+    },
+    // Empty toThrowError
+    {
+      code: "expect(() => { throw new Error('a'); }).toThrowError();",
+      errors: [
+        {
+          message: 'Add an error message to toThrowError()',
+          column: 41,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/valid-describe.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/valid-describe.test.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../valid-describe');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8,
+  },
+});
+
+ruleTester.run('valid-describe', rule, {
+  valid: [
+    'describe("foo", function() {})',
+    'describe("foo", () => {})',
+    'describe(`foo`, () => {})',
+    'xdescribe("foo", () => {})',
+    'fdescribe("foo", () => {})',
+    'describe.only("foo", () => {})',
+    'describe.skip("foo", () => {})',
+    `
+    describe('foo', () => {
+      it('bar', () => {
+        return Promise.resolve(42).then(value => {
+          expect(value).toBe(42)
+        })
+      })
+    })
+    `,
+    `
+    describe('foo', () => {
+      it('bar', async () => {
+        expect(await Promise.resolve(42)).toBe(42)
+      })
+    })
+    `,
+    `
+    describe('foo', () =>
+      test('bar', () => {})
+    )
+    `,
+  ],
+  invalid: [
+    {
+      code: 'describe(() => {})',
+      errors: [
+        {
+          message: 'First argument must be name',
+          line: 1,
+          column: 10,
+        },
+        {
+          message: 'Describe requires name and callback arguments',
+          line: 1,
+          column: 10,
+        },
+      ],
+    },
+    {
+      code: 'describe("foo")',
+      errors: [
+        {
+          message: 'Describe requires name and callback arguments',
+          line: 1,
+          column: 10,
+        },
+      ],
+    },
+    {
+      code: 'describe("foo", "foo2")',
+      errors: [
+        {
+          message: 'Second argument must be function',
+          line: 1,
+          column: 10,
+        },
+      ],
+    },
+    {
+      code: 'describe()',
+      errors: [
+        {
+          message: 'Describe requires name and callback arguments',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: 'describe("foo", async () => {})',
+      errors: [{ message: 'No async describe callback', line: 1, column: 17 }],
+    },
+    {
+      code: 'describe("foo", async function () {})',
+      errors: [{ message: 'No async describe callback', line: 1, column: 17 }],
+    },
+    {
+      code: 'xdescribe("foo", async function () {})',
+      errors: [{ message: 'No async describe callback', line: 1, column: 18 }],
+    },
+    {
+      code: 'fdescribe("foo", async function () {})',
+      errors: [{ message: 'No async describe callback', line: 1, column: 18 }],
+    },
+    {
+      code: 'describe.only("foo", async function () {})',
+      errors: [{ message: 'No async describe callback', line: 1, column: 22 }],
+    },
+    {
+      code: 'describe.skip("foo", async function () {})',
+      errors: [{ message: 'No async describe callback', line: 1, column: 22 }],
+    },
+    {
+      code: `
+      describe('sample case', () => {
+        it('works', () => {
+          expect(true).toEqual(true);
+        });
+        describe('async', async () => {
+          await new Promise(setImmediate);
+          it('breaks', () => {
+            throw new Error('Fail');
+          });
+        });
+      });`,
+      errors: [{ message: 'No async describe callback', line: 6, column: 27 }],
+    },
+    {
+      code: `
+      describe('foo', function () {
+        return Promise.resolve().then(() => {
+          it('breaks', () => {
+            throw new Error('Fail')
+          })
+        })
+      })
+      `,
+      errors: [
+        {
+          message: 'Unexpected return statement in describe callback',
+          line: 3,
+          column: 9,
+        },
+      ],
+    },
+    {
+      code: `
+      describe('foo', () => {
+        return Promise.resolve().then(() => {
+          it('breaks', () => {
+            throw new Error('Fail')
+          })
+        })
+        describe('nested', () => {
+          return Promise.resolve().then(() => {
+            it('breaks', () => {
+              throw new Error('Fail')
+            })
+          })
+        })
+      })
+      `,
+      errors: [
+        {
+          message: 'Unexpected return statement in describe callback',
+          line: 3,
+          column: 9,
+        },
+        {
+          message: 'Unexpected return statement in describe callback',
+          line: 9,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `
+      describe('foo', async () => {
+        await something()
+        it('does something')
+        describe('nested', () => {
+          return Promise.resolve().then(() => {
+            it('breaks', () => {
+              throw new Error('Fail')
+            })
+          })
+        })
+      })
+      `,
+      errors: [
+        {
+          message: 'No async describe callback',
+          line: 2,
+          column: 23,
+        },
+        {
+          message: 'Unexpected return statement in describe callback',
+          line: 6,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: 'describe("foo", done => {})',
+      errors: [
+        {
+          message: 'Unexpected argument(s) in describe callback',
+          line: 1,
+          column: 17,
+        },
+      ],
+    },
+    {
+      code: 'describe("foo", function (done) {})',
+      errors: [
+        {
+          message: 'Unexpected argument(s) in describe callback',
+          line: 1,
+          column: 27,
+        },
+      ],
+    },
+    {
+      code: 'describe("foo", function (one, two, three) {})',
+      errors: [
+        {
+          message: 'Unexpected argument(s) in describe callback',
+          line: 1,
+          column: 27,
+        },
+      ],
+    },
+    {
+      code: 'describe("foo", async function (done) {})',
+      errors: [
+        { message: 'No async describe callback', line: 1, column: 17 },
+        {
+          message: 'Unexpected argument(s) in describe callback',
+          line: 1,
+          column: 33,
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/valid-expect-in-promise.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/valid-expect-in-promise.test.js
@@ -1,0 +1,401 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../valid-expect-in-promise');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8,
+  },
+});
+
+const expectedMsg =
+  'Promise should be returned to test its fulfillment or rejection';
+
+ruleTester.run('valid-expect-in-promise', rule, {
+  invalid: [
+    {
+      code: `
+         it('it1', () => {
+           somePromise.then(() => {
+             expect(someThing).toEqual(true);
+           });
+         });
+      `,
+      errors: [
+        {
+          column: 12,
+          endColumn: 15,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function() {
+            getSomeThing().getPromise().then(function() {
+              expect(someThing).toEqual(true);
+            });
+        });
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 16,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function() {
+            Promise.resolve().then(function() {
+              expect(someThing).toEqual(true);
+            });
+          });
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 16,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function() {
+            somePromise.catch(function() {
+              expect(someThing).toEqual(true)
+            })
+          }
+        )
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 15,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function() {
+            somePromise.then(function() {
+              expect(someThing).toEqual(true)
+            })
+          }
+        )
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 15,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function () {
+          Promise.resolve().then(/*fulfillment*/ function () {
+            expect(someThing).toEqual(true);
+          }, /*rejection*/ function () {
+            expect(someThing).toEqual(true);
+          })
+        })
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 13,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function () {
+          Promise.resolve().then(/*fulfillment*/ function () {
+          }, /*rejection*/ function () {
+            expect(someThing).toEqual(true)
+          })
+        });
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 13,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('test function', () => {
+          Builder.getPromiseBuilder().get().build().then((data) => expect(data).toEqual('Hi'));
+        });
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 96,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', () => {
+            somePromise.then(() => {
+              doSomeOperation();
+              expect(someThing).toEqual(true);
+            })
+          });
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 15,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+         test('invalid return', () => {
+           const promise = something().then(value => {
+             const foo = "foo";
+             return expect(value).toBe('red');
+           });
+         });
+      `,
+      errors: [
+        {
+          column: 18,
+          endColumn: 14,
+          message: expectedMsg,
+        },
+      ],
+    },
+  ],
+
+  valid: [
+    `
+      it('it1', () => new Promise((done) => {
+        test()
+          .then(() => {
+            expect(someThing).toEqual(true);
+            done();
+          });
+      }));
+    `,
+    `
+      it('it1', () => {
+        return somePromise.then(() => {
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
+
+    `
+      it('it1', function() {
+        return somePromise.catch(function() {
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
+
+    `
+      it('it1', function() {
+        return somePromise.then(function() {
+          doSomeThingButNotExpect();
+        });
+      });
+    `,
+
+    `
+      it('it1', function() {
+        return getSomeThing().getPromise().then(function() {
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
+
+    `
+      it('it1', function() {
+        return Promise.resolve().then(function() {
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
+
+    `
+      it('it1', function () {
+        return Promise.resolve().then(function () {
+          /*fulfillment*/
+          expect(someThing).toEqual(true);
+        }, function () {
+          /*rejection*/
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
+
+    `
+      it('it1', function () {
+        return Promise.resolve().then(function () {
+          /*fulfillment*/
+        }, function () {
+          /*rejection*/
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
+
+    `
+      it('it1', function () {
+        return somePromise.then()
+      });
+    `,
+
+    `
+      it('it1', async () => {
+        await Promise.resolve().then(function () {
+          expect(someThing).toEqual(true)
+        });
+      });
+    `,
+
+    `
+      it('it1', async () => {
+        await somePromise.then(() => {
+          expect(someThing).toEqual(true)
+        });
+      });
+    `,
+
+    `
+      it('it1', async () => {
+        await getSomeThing().getPromise().then(function () {
+          expect(someThing).toEqual(true)
+        });
+      });
+    `,
+
+    `
+      it('it1', () => {
+        return somePromise.then(() => {
+            expect(someThing).toEqual(true);
+          })
+          .then(() => {
+            expect(someThing).toEqual(true);
+          })
+      });
+    `,
+
+    `
+      it('it1', () => {
+        return somePromise.then(() => {
+            expect(someThing).toEqual(true);
+          })
+          .catch(() => {
+            expect(someThing).toEqual(false);
+          })
+      });
+    `,
+
+    `
+     test('later return', () => {
+       const promise = something().then(value => {
+         expect(value).toBe('red');
+       });
+
+       return promise;
+     });
+    `,
+
+    `
+     it('shorthand arrow', () =>
+       something().then(value => {
+         expect(() => {
+           value();
+         }).toThrow();
+       }));
+    `,
+
+    `
+      it('promise test', () => {
+        const somePromise = getThatPromise();
+        somePromise.then((data) => {
+          expect(data).toEqual('foo');
+        });
+        expect(somePromise).toBeDefined();
+        return somePromise;
+      });
+    `,
+
+    `
+      test('promise test', function () {
+        let somePromise = getThatPromise();
+        somePromise.then((data) => {
+          expect(data).toEqual('foo');
+        });
+        expect(somePromise).toBeDefined();
+        return somePromise;
+      });
+    `,
+
+    `
+      it('crawls for files based on patterns', () => {
+        const promise = nodeCrawl({}).then(data => {
+          expect(childProcess.spawn).lastCalledWith('find');
+        });
+        return promise;
+      });
+    `,
+
+    `
+      it('test function',
+        () => {
+          return Builder.getPromiseBuilder().get().build()
+            .then((data) => {
+              expect(data).toEqual('Hi');
+            });
+      });
+    `,
+
+    `
+      notATestFunction('not a test function',
+        () => {
+          Builder.getPromiseBuilder().get().build()
+            .then((data) => {
+              expect(data).toEqual('Hi');
+            });
+      });
+    `,
+
+    `
+      it("it1", () => somePromise.then(() => {
+        expect(someThing).toEqual(true)
+      }))
+    `,
+
+    ` it("it1", () => somePromise.then(() => expect(someThing).toEqual(true)))`,
+
+    `
+      it('promise test with done', (done) => {
+        const promise = getPromise();
+        promise.then(() => expect(someThing).toEqual(true));
+      });
+    `,
+
+    `
+      it('name of done param does not matter', (nameDoesNotMatter) => {
+        const promise = getPromise();
+        promise.then(() => expect(someThing).toEqual(true));
+      });
+    `,
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/__tests__/valid-expect.test.js
+++ b/node_modules/eslint-plugin-jest/rules/__tests__/valid-expect.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../valid-expect');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('valid-expect', rule, {
+  valid: [
+    'expect("something").toEqual("else");',
+    'expect(true).toBeDefined();',
+    'expect([1, 2, 3]).toEqual([1, 2, 3]);',
+    'expect(undefined).not.toBeDefined();',
+    'expect(Promise.resolve(2)).resolves.toBeDefined();',
+    'expect(Promise.reject(2)).rejects.toBeDefined();',
+  ],
+
+  invalid: [
+    {
+      code: 'expect().toBe(true);',
+      errors: [
+        {
+          endColumn: 8,
+          column: 7,
+          message: 'No arguments were passed to expect().',
+        },
+      ],
+    },
+    {
+      code: 'expect().toEqual("something");',
+      errors: [
+        {
+          endColumn: 8,
+          column: 7,
+          message: 'No arguments were passed to expect().',
+        },
+      ],
+    },
+    {
+      code: 'expect("something", "else").toEqual("something");',
+      errors: [
+        {
+          endColumn: 26,
+          column: 21,
+          message: 'More than one argument was passed to expect().',
+        },
+      ],
+    },
+    {
+      code: 'expect("something");',
+      errors: [
+        {
+          endColumn: 20,
+          column: 1,
+          message: 'No assertion was called on expect().',
+        },
+      ],
+    },
+    {
+      code: 'expect();',
+      errors: [
+        {
+          endColumn: 9,
+          column: 1,
+          message: 'No assertion was called on expect().',
+        },
+        {
+          endColumn: 8,
+          column: 7,
+          message: 'No arguments were passed to expect().',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).toBeDefined;',
+      errors: [
+        {
+          endColumn: 25,
+          column: 14,
+          message: '"toBeDefined" was not called.',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).not.toBeDefined;',
+      errors: [
+        {
+          endColumn: 29,
+          column: 18,
+          message: '"toBeDefined" was not called.',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).nope.toBeDefined;',
+      errors: [
+        {
+          endColumn: 18,
+          column: 14,
+          message: '"nope" is not a valid property of expect.',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).resolves;',
+      errors: [
+        {
+          endColumn: 22,
+          column: 14,
+          message: '"resolves" needs to call a matcher.',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).rejects;',
+      errors: [
+        {
+          endColumn: 21,
+          column: 14,
+          message: '"rejects" needs to call a matcher.',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).not;',
+      errors: [
+        {
+          endColumn: 17,
+          column: 14,
+          message: '"not" needs to call a matcher.',
+        },
+      ],
+    },
+  ],
+});

--- a/node_modules/eslint-plugin-jest/rules/consistent-test-it.js
+++ b/node_modules/eslint-plugin-jest/rules/consistent-test-it.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const { getDocsUrl, getNodeName, isTestCase, isDescribe } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          fn: {
+            enum: ['it', 'test'],
+          },
+          withinDescribe: {
+            enum: ['it', 'test'],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const configObj = context.options[0] || {};
+    const testKeyword = configObj.fn || 'test';
+    const testKeywordWithinDescribe =
+      configObj.withinDescribe || configObj.fn || 'it';
+
+    let describeNestingLevel = 0;
+
+    return {
+      CallExpression(node) {
+        const nodeName = getNodeName(node.callee);
+
+        if (isDescribe(node)) {
+          describeNestingLevel++;
+        }
+
+        if (
+          isTestCase(node) &&
+          describeNestingLevel === 0 &&
+          nodeName.indexOf(testKeyword) === -1
+        ) {
+          const oppositeTestKeyword = getOppositeTestKeyword(testKeyword);
+
+          context.report({
+            message:
+              "Prefer using '{{ testKeyword }}' instead of '{{ oppositeTestKeyword }}'",
+            node: node.callee,
+            data: { testKeyword, oppositeTestKeyword },
+            fix(fixer) {
+              const nodeToReplace =
+                node.callee.type === 'MemberExpression'
+                  ? node.callee.object
+                  : node.callee;
+
+              const fixedNodeName = getPreferredNodeName(nodeName, testKeyword);
+              return [fixer.replaceText(nodeToReplace, fixedNodeName)];
+            },
+          });
+        }
+
+        if (
+          isTestCase(node) &&
+          describeNestingLevel > 0 &&
+          nodeName.indexOf(testKeywordWithinDescribe) === -1
+        ) {
+          const oppositeTestKeyword = getOppositeTestKeyword(
+            testKeywordWithinDescribe
+          );
+
+          context.report({
+            message:
+              "Prefer using '{{ testKeywordWithinDescribe }}' instead of '{{ oppositeTestKeyword }}' within describe",
+            node: node.callee,
+            data: { testKeywordWithinDescribe, oppositeTestKeyword },
+            fix(fixer) {
+              const nodeToReplace =
+                node.callee.type === 'MemberExpression'
+                  ? node.callee.object
+                  : node.callee;
+
+              const fixedNodeName = getPreferredNodeName(
+                nodeName,
+                testKeywordWithinDescribe
+              );
+              return [fixer.replaceText(nodeToReplace, fixedNodeName)];
+            },
+          });
+        }
+      },
+      'CallExpression:exit'(node) {
+        if (isDescribe(node)) {
+          describeNestingLevel--;
+        }
+      },
+    };
+  },
+};
+
+function getPreferredNodeName(nodeName, preferredTestKeyword) {
+  switch (nodeName) {
+    case 'fit':
+      return 'test.only';
+    default:
+      return nodeName.startsWith('f') || nodeName.startsWith('x')
+        ? nodeName.charAt(0) + preferredTestKeyword
+        : preferredTestKeyword;
+  }
+}
+
+function getOppositeTestKeyword(test) {
+  if (test === 'test') {
+    return 'it';
+  }
+
+  return 'test';
+}

--- a/node_modules/eslint-plugin-jest/rules/expect-expect.js
+++ b/node_modules/eslint-plugin-jest/rules/expect-expect.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/*
+ * This implementation is adapted from eslint-plugin-jasmine.
+ * MIT license, Remco Haszing.
+ */
+
+const { getDocsUrl, getNodeName } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          assertFunctionNames: {
+            type: 'array',
+            items: [{ type: 'string' }],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const unchecked = [];
+    const assertFunctionNames = new Set(
+      context.options[0] && context.options[0].assertFunctionNames
+        ? context.options[0].assertFunctionNames
+        : ['expect']
+    );
+
+    return {
+      CallExpression(node) {
+        const name = getNodeName(node.callee);
+        if (name === 'it' || name === 'test') {
+          unchecked.push(node);
+        } else if (assertFunctionNames.has(name)) {
+          // Return early in case of nested `it` statements.
+          for (const ancestor of context.getAncestors()) {
+            const index = unchecked.indexOf(ancestor);
+            if (index !== -1) {
+              unchecked.splice(index, 1);
+              break;
+            }
+          }
+        }
+      },
+      'Program:exit'() {
+        unchecked.forEach(node =>
+          context.report({
+            message: 'Test has no assertions',
+            node,
+          })
+        );
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/lowercase-name.js
+++ b/node_modules/eslint-plugin-jest/rules/lowercase-name.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { getDocsUrl } = require('./util');
+
+const isItTestOrDescribeFunction = node => {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee &&
+    (node.callee.name === 'it' ||
+      node.callee.name === 'test' ||
+      node.callee.name === 'describe')
+  );
+};
+
+const isItDescription = node => {
+  return (
+    node.arguments &&
+    node.arguments[0] &&
+    (node.arguments[0].type === 'Literal' ||
+      node.arguments[0].type === 'TemplateLiteral')
+  );
+};
+
+const testDescription = node => {
+  const [firstArgument] = node.arguments;
+  const { type } = firstArgument;
+
+  if (type === 'Literal') {
+    return firstArgument.value;
+  }
+
+  // `isItDescription` guarantees this is `type === 'TemplateLiteral'`
+  return firstArgument.quasis[0].value.raw;
+};
+
+const descriptionBeginsWithLowerCase = node => {
+  if (isItTestOrDescribeFunction(node) && isItDescription(node)) {
+    const description = testDescription(node);
+    if (!description[0]) {
+      return false;
+    }
+
+    if (description[0] !== description[0].toLowerCase()) {
+      return node.callee.name;
+    }
+  }
+  return false;
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    const ignore = (context.options[0] && context.options[0].ignore) || [];
+    const ignoredFunctionNames = ignore.reduce((accumulator, value) => {
+      accumulator[value] = true;
+      return accumulator;
+    }, Object.create(null));
+
+    const isIgnoredFunctionName = node =>
+      ignoredFunctionNames[node.callee.name];
+
+    return {
+      CallExpression(node) {
+        const erroneousMethod = descriptionBeginsWithLowerCase(node);
+
+        if (erroneousMethod && !isIgnoredFunctionName(node)) {
+          context.report({
+            message: '`{{ method }}`s should begin with lowercase',
+            data: { method: erroneousMethod },
+            node,
+            fix(fixer) {
+              const [firstArg] = node.arguments;
+              const description = testDescription(node);
+
+              const rangeIgnoringQuotes = [
+                firstArg.range[0] + 1,
+                firstArg.range[1] - 1,
+              ];
+              const newDescription =
+                description.substring(0, 1).toLowerCase() +
+                description.substring(1);
+
+              return [
+                fixer.replaceTextRange(rangeIgnoringQuotes, newDescription),
+              ];
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-alias-methods.js
+++ b/node_modules/eslint-plugin-jest/rules/no-alias-methods.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { expectCase, getDocsUrl, method } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    // The Jest methods which have aliases. The canonical name is the first
+    // index of each item.
+    const methodNames = [
+      ['toHaveBeenCalled', 'toBeCalled'],
+      ['toHaveBeenCalledTimes', 'toBeCalledTimes'],
+      ['toHaveBeenCalledWith', 'toBeCalledWith'],
+      ['toHaveBeenLastCalledWith', 'lastCalledWith'],
+      ['toHaveBeenNthCalledWith', 'nthCalledWith'],
+      ['toHaveReturned', 'toReturn'],
+      ['toHaveReturnedTimes', 'toReturnTimes'],
+      ['toHaveReturnedWith', 'toReturnWith'],
+      ['toHaveLastReturnedWith', 'lastReturnedWith'],
+      ['toHaveNthReturnedWith', 'nthReturnedWith'],
+      ['toThrow', 'toThrowError'],
+    ];
+
+    return {
+      CallExpression(node) {
+        if (!expectCase(node)) {
+          return;
+        }
+
+        let targetNode = method(node);
+        if (
+          targetNode.name === 'resolves' ||
+          targetNode.name === 'rejects' ||
+          targetNode.name === 'not'
+        ) {
+          targetNode = method(node.parent);
+        }
+
+        if (!targetNode) {
+          return;
+        }
+
+        // Check if the method used matches any of ours
+        const methodItem = methodNames.find(
+          item => item[1] === targetNode.name
+        );
+
+        if (methodItem) {
+          context.report({
+            message: `Replace {{ replace }}() with its canonical name of {{ canonical }}()`,
+            data: {
+              replace: methodItem[1],
+              canonical: methodItem[0],
+            },
+            node: targetNode,
+            fix(fixer) {
+              return [fixer.replaceText(targetNode, methodItem[0])];
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-disabled-tests.js
+++ b/node_modules/eslint-plugin-jest/rules/no-disabled-tests.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { getDocsUrl, getNodeName, scopeHasLocalReference } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    let suiteDepth = 0;
+    let testDepth = 0;
+
+    return {
+      'CallExpression[callee.name="describe"]'() {
+        suiteDepth++;
+      },
+      'CallExpression[callee.name=/^(it|test)$/]'() {
+        testDepth++;
+      },
+      'CallExpression[callee.name=/^(it|test)$/][arguments.length<2]'(node) {
+        context.report({
+          message: 'Test is missing function argument',
+          node,
+        });
+      },
+      CallExpression(node) {
+        const functionName = getNodeName(node.callee);
+
+        switch (functionName) {
+          case 'describe.skip':
+            context.report({ message: 'Skipped test suite', node });
+            break;
+
+          case 'it.skip':
+          case 'test.skip':
+            context.report({ message: 'Skipped test', node });
+            break;
+        }
+      },
+      'CallExpression[callee.name="pending"]'(node) {
+        if (scopeHasLocalReference(context.getScope(), 'pending')) {
+          return;
+        }
+
+        if (testDepth > 0) {
+          context.report({
+            message: 'Call to pending() within test',
+            node,
+          });
+        } else if (suiteDepth > 0) {
+          context.report({
+            message: 'Call to pending() within test suite',
+            node,
+          });
+        } else {
+          context.report({
+            message: 'Call to pending()',
+            node,
+          });
+        }
+      },
+      'CallExpression[callee.name="xdescribe"]'(node) {
+        context.report({ message: 'Disabled test suite', node });
+      },
+      'CallExpression[callee.name=/^xit|xtest$/]'(node) {
+        context.report({ message: 'Disabled test', node });
+      },
+      'CallExpression[callee.name="describe"]:exit'() {
+        suiteDepth--;
+      },
+      'CallExpression[callee.name=/^it|test$/]:exit'() {
+        testDepth--;
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-empty-title.js
+++ b/node_modules/eslint-plugin-jest/rules/no-empty-title.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const {
+  getDocsUrl,
+  hasExpressions,
+  isDescribe,
+  isTestCase,
+  isTemplateLiteral,
+  isString,
+  getStringValue,
+} = require('./util');
+
+const errorMessages = {
+  describe: 'describe should not have an empty title',
+  test: 'test should not have an empty title',
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const is = {
+          describe: isDescribe(node),
+          testCase: isTestCase(node),
+        };
+        if (!is.describe && !is.testCase) {
+          return;
+        }
+        const [firstArgument] = node.arguments;
+        if (!isString(firstArgument)) {
+          return;
+        }
+        if (isTemplateLiteral(firstArgument) && hasExpressions(firstArgument)) {
+          return;
+        }
+        if (getStringValue(firstArgument) === '') {
+          const message = is.describe
+            ? errorMessages.describe
+            : errorMessages.test;
+          context.report({
+            message,
+            node,
+          });
+        }
+      },
+    };
+  },
+  errorMessages,
+};

--- a/node_modules/eslint-plugin-jest/rules/no-focused-tests.js
+++ b/node_modules/eslint-plugin-jest/rules/no-focused-tests.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const { getDocsUrl } = require('./util');
+
+const testFunctions = Object.assign(Object.create(null), {
+  describe: true,
+  it: true,
+  test: true,
+});
+
+const matchesTestFunction = object => object && testFunctions[object.name];
+
+const isCallToFocusedTestFunction = object =>
+  object && object.name[0] === 'f' && testFunctions[object.name.substring(1)];
+
+const isPropertyNamedOnly = property =>
+  property && (property.name === 'only' || property.value === 'only');
+
+const isCallToTestOnlyFunction = callee =>
+  matchesTestFunction(callee.object) && isPropertyNamedOnly(callee.property);
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create: context => ({
+    CallExpression(node) {
+      const { callee } = node;
+
+      if (callee.type === 'MemberExpression') {
+        if (
+          callee.object.type === 'Identifier' &&
+          isCallToFocusedTestFunction(callee.object)
+        ) {
+          context.report({
+            message: 'Unexpected focused test.',
+            node: callee.object,
+          });
+          return;
+        }
+
+        if (
+          callee.object.type === 'MemberExpression' &&
+          isCallToTestOnlyFunction(callee.object)
+        ) {
+          context.report({
+            message: 'Unexpected focused test.',
+            node: callee.object.property,
+          });
+          return;
+        }
+
+        if (isCallToTestOnlyFunction(callee)) {
+          context.report({
+            message: 'Unexpected focused test.',
+            node: callee.property,
+          });
+          return;
+        }
+      }
+
+      if (callee.type === 'Identifier' && isCallToFocusedTestFunction(callee)) {
+        context.report({
+          message: 'Unexpected focused test.',
+          node: callee,
+        });
+        return;
+      }
+    },
+  }),
+};

--- a/node_modules/eslint-plugin-jest/rules/no-hooks.js
+++ b/node_modules/eslint-plugin-jest/rules/no-hooks.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { getDocsUrl } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  schema: [
+    {
+      type: 'object',
+      properties: {
+        allow: {
+          type: 'array',
+          contains: ['beforeAll', 'beforeEach', 'afterAll', 'afterEach'],
+        },
+      },
+      additionalProperties: false,
+    },
+  ],
+  create(context) {
+    const testHookNames = Object.assign(Object.create(null), {
+      beforeAll: true,
+      beforeEach: true,
+      afterAll: true,
+      afterEach: true,
+    });
+
+    const whitelistedHookNames = (
+      context.options[0] || { allow: [] }
+    ).allow.reduce((hashMap, value) => {
+      hashMap[value] = true;
+      return hashMap;
+    }, Object.create(null));
+
+    const isHook = node => testHookNames[node.callee.name];
+    const isWhitelisted = node => whitelistedHookNames[node.callee.name];
+
+    return {
+      CallExpression(node) {
+        if (isHook(node) && !isWhitelisted(node)) {
+          context.report({
+            node,
+            message: "Unexpected '{{ hookName }}' hook",
+            data: { hookName: node.callee.name },
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-identical-title.js
+++ b/node_modules/eslint-plugin-jest/rules/no-identical-title.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const {
+  getDocsUrl,
+  isDescribe,
+  isTestCase,
+  isString,
+  hasExpressions,
+  getStringValue,
+} = require('./util');
+
+const newDescribeContext = () => ({
+  describeTitles: [],
+  testTitles: [],
+});
+
+const handleTestCaseTitles = (context, titles, node, title) => {
+  if (isTestCase(node)) {
+    if (titles.indexOf(title) !== -1) {
+      context.report({
+        message:
+          'Test title is used multiple times in the same describe block.',
+        node,
+      });
+    }
+    titles.push(title);
+  }
+};
+
+const handleDescribeBlockTitles = (context, titles, node, title) => {
+  if (!isDescribe(node)) {
+    return;
+  }
+  if (titles.indexOf(title) !== -1) {
+    context.report({
+      message:
+        'Describe block title is used multiple times in the same describe block.',
+      node,
+    });
+  }
+  titles.push(title);
+};
+
+const isFirstArgValid = arg => {
+  if (!arg || !isString(arg)) {
+    return false;
+  }
+  if (arg.type === 'TemplateLiteral' && hasExpressions(arg)) {
+    return false;
+  }
+  return true;
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    const contexts = [newDescribeContext()];
+    return {
+      CallExpression(node) {
+        const currentLayer = contexts[contexts.length - 1];
+        if (isDescribe(node)) {
+          contexts.push(newDescribeContext());
+        }
+        const [firstArgument] = node.arguments;
+        if (!isFirstArgValid(firstArgument)) {
+          return;
+        }
+        const title = getStringValue(firstArgument);
+        handleTestCaseTitles(context, currentLayer.testTitles, node, title);
+        handleDescribeBlockTitles(
+          context,
+          currentLayer.describeTitles,
+          node,
+          title
+        );
+      },
+      'CallExpression:exit'(node) {
+        if (isDescribe(node)) {
+          contexts.pop();
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-jasmine-globals.js
+++ b/node_modules/eslint-plugin-jest/rules/no-jasmine-globals.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const { getDocsUrl, getNodeName, scopeHasLocalReference } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+    messages: {
+      illegalGlobal:
+        'Illegal usage of global `{{ global }}`, prefer `{{ replacement }}`',
+      illegalMethod:
+        'Illegal usage of `{{ method }}`, prefer `{{ replacement }}`',
+      illegalFail:
+        'Illegal usage of `fail`, prefer throwing an error, or the `done.fail` callback',
+      illegalPending:
+        'Illegal usage of `pending`, prefer explicitly skipping a test using `test.skip`',
+      illegalJasmine: 'Illegal usage of jasmine global',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const calleeName = getNodeName(node.callee);
+
+        if (!calleeName) {
+          return;
+        }
+        if (
+          calleeName === 'spyOn' ||
+          calleeName === 'spyOnProperty' ||
+          calleeName === 'fail' ||
+          calleeName === 'pending'
+        ) {
+          if (scopeHasLocalReference(context.getScope(), calleeName)) {
+            // It's a local variable, not a jasmine global.
+            return;
+          }
+
+          switch (calleeName) {
+            case 'spyOn':
+            case 'spyOnProperty':
+              context.report({
+                node,
+                messageId: 'illegalGlobal',
+                data: { global: calleeName, replacement: 'jest.spyOn' },
+              });
+              break;
+            case 'fail':
+              context.report({
+                node,
+                messageId: 'illegalFail',
+              });
+              break;
+            case 'pending':
+              context.report({
+                node,
+                messageId: 'illegalPending',
+              });
+              break;
+          }
+          return;
+        }
+
+        if (calleeName.startsWith('jasmine.')) {
+          const functionName = calleeName.replace('jasmine.', '');
+
+          if (
+            functionName === 'any' ||
+            functionName === 'anything' ||
+            functionName === 'arrayContaining' ||
+            functionName === 'objectContaining' ||
+            functionName === 'stringMatching'
+          ) {
+            context.report({
+              fix(fixer) {
+                return [fixer.replaceText(node.callee.object, 'expect')];
+              },
+              node,
+              messageId: 'illegalMethod',
+              data: {
+                method: calleeName,
+                replacement: `expect.${functionName}`,
+              },
+            });
+            return;
+          }
+
+          if (functionName === 'addMatchers') {
+            context.report({
+              node,
+              messageId: 'illegalMethod',
+              data: {
+                method: calleeName,
+                replacement: `expect.extend`,
+              },
+            });
+            return;
+          }
+
+          if (functionName === 'createSpy') {
+            context.report({
+              node,
+              messageId: 'illegalMethod',
+              data: {
+                method: calleeName,
+                replacement: 'jest.fn',
+              },
+            });
+            return;
+          }
+
+          context.report({
+            node,
+            messageId: 'illegalJasmine',
+          });
+        }
+      },
+      MemberExpression(node) {
+        if (node.object.name === 'jasmine') {
+          if (node.parent.type === 'AssignmentExpression') {
+            if (node.property.name === 'DEFAULT_TIMEOUT_INTERVAL') {
+              context.report({
+                fix(fixer) {
+                  return [
+                    fixer.replaceText(
+                      node.parent,
+                      `jest.setTimeout(${node.parent.right.value})`
+                    ),
+                  ];
+                },
+                node,
+                message: 'Illegal usage of jasmine global',
+              });
+              return;
+            }
+
+            context.report({
+              node,
+              message: 'Illegal usage of jasmine global',
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-jest-import.js
+++ b/node_modules/eslint-plugin-jest/rules/no-jest-import.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { getDocsUrl } = require('./util');
+
+const message = `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`;
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      'ImportDeclaration[source.value="jest"]'(node) {
+        context.report({ node, message });
+      },
+      'CallExpression[callee.name="require"][arguments.0.value="jest"]'(node) {
+        context.report({
+          loc: node.arguments[0].loc,
+          message,
+        });
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-large-snapshots.js
+++ b/node_modules/eslint-plugin-jest/rules/no-large-snapshots.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { getDocsUrl } = require('./util');
+
+const reportOnViolation = (context, node) => {
+  const lineLimit =
+    context.options[0] && Number.isFinite(context.options[0].maxSize)
+      ? context.options[0].maxSize
+      : 50;
+  const startLine = node.loc.start.line;
+  const endLine = node.loc.end.line;
+  const lineCount = endLine - startLine;
+
+  if (lineCount > lineLimit) {
+    context.report({
+      message:
+        lineLimit === 0
+          ? 'Expected to not encounter a Jest snapshot but was found with {{ lineCount }} lines long'
+          : 'Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long',
+      data: { lineLimit, lineCount },
+      node,
+    });
+  }
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    if (context.getFilename().endsWith('.snap')) {
+      return {
+        ExpressionStatement(node) {
+          reportOnViolation(context, node);
+        },
+      };
+    } else if (context.getFilename().endsWith('.js')) {
+      return {
+        CallExpression(node) {
+          const propertyName =
+            node.callee.property && node.callee.property.name;
+          if (
+            propertyName === 'toMatchInlineSnapshot' ||
+            propertyName === 'toThrowErrorMatchingInlineSnapshot'
+          ) {
+            reportOnViolation(context, node);
+          }
+        },
+      };
+    }
+
+    return {};
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-mocks-import.js
+++ b/node_modules/eslint-plugin-jest/rules/no-mocks-import.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { posix } = require('path');
+const { getDocsUrl } = require('./util');
+
+const mocksDirName = '__mocks__';
+const message = `Mocks should not be manually imported from a ${mocksDirName} directory. Instead use jest.mock and import from the original module path.`;
+
+const isMockPath = path => path.split(posix.sep).includes(mocksDirName);
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (isMockPath(node.source.value)) {
+          context.report({ node, message });
+        }
+      },
+      'CallExpression[callee.name="require"]'(node) {
+        if (
+          node.arguments.length &&
+          node.arguments[0].value &&
+          isMockPath(node.arguments[0].value)
+        ) {
+          context.report({
+            loc: node.arguments[0].loc,
+            message,
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-test-callback.js
+++ b/node_modules/eslint-plugin-jest/rules/no-test-callback.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const { getDocsUrl, isTestCase } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isTestCase(node) || node.arguments.length !== 2) {
+          return;
+        }
+
+        const [, callback] = node.arguments;
+
+        if (
+          !/^(Arrow)?FunctionExpression$/.test(callback.type) ||
+          callback.params.length !== 1
+        ) {
+          return;
+        }
+
+        const [argument] = callback.params;
+        context.report({
+          node: argument,
+          message: 'Illegal usage of test callback',
+          fix(fixer) {
+            const sourceCode = context.getSourceCode();
+            const { body } = callback;
+            const firstBodyToken = sourceCode.getFirstToken(body);
+            const lastBodyToken = sourceCode.getLastToken(body);
+            const tokenBeforeArgument = sourceCode.getTokenBefore(argument);
+            const tokenAfterArgument = sourceCode.getTokenAfter(argument);
+            const argumentInParens =
+              tokenBeforeArgument.value === '(' &&
+              tokenAfterArgument.value === ')';
+
+            let argumentFix = fixer.replaceText(argument, '()');
+
+            if (argumentInParens) {
+              argumentFix = fixer.remove(argument);
+            }
+
+            let newCallback = argument.name;
+
+            if (argumentInParens) {
+              newCallback = `(${newCallback})`;
+            }
+
+            let beforeReplacement = `new Promise(${newCallback} => `;
+            let afterReplacement = ')';
+            let replaceBefore = true;
+
+            if (body.type === 'BlockStatement') {
+              const keyword = callback.async ? 'await' : 'return';
+
+              beforeReplacement = `${keyword} ${beforeReplacement}{`;
+              afterReplacement += '}';
+              replaceBefore = false;
+            }
+
+            return [
+              argumentFix,
+              replaceBefore
+                ? fixer.insertTextBefore(firstBodyToken, beforeReplacement)
+                : fixer.insertTextAfter(firstBodyToken, beforeReplacement),
+              fixer.insertTextAfter(lastBodyToken, afterReplacement),
+            ];
+          },
+        });
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-test-prefixes.js
+++ b/node_modules/eslint-plugin-jest/rules/no-test-prefixes.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { getDocsUrl, getNodeName, isTestCase, isDescribe } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const nodeName = getNodeName(node.callee);
+
+        if (!isDescribe(node) && !isTestCase(node)) return;
+
+        const preferredNodeName = getPreferredNodeName(nodeName);
+
+        if (!preferredNodeName) return;
+
+        context.report({
+          message: 'Use "{{ preferredNodeName }}" instead',
+          node: node.callee,
+          data: { preferredNodeName },
+          fix(fixer) {
+            return [fixer.replaceText(node.callee, preferredNodeName)];
+          },
+        });
+      },
+    };
+  },
+};
+
+function getPreferredNodeName(nodeName) {
+  const firstChar = nodeName.charAt(0);
+
+  if (firstChar === 'f') {
+    return `${nodeName.slice(1)}.only`;
+  }
+
+  if (firstChar === 'x') {
+    return `${nodeName.slice(1)}.skip`;
+  }
+}

--- a/node_modules/eslint-plugin-jest/rules/no-test-return-statement.js
+++ b/node_modules/eslint-plugin-jest/rules/no-test-return-statement.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const { getDocsUrl, isFunction, isTestCase } = require('./util');
+
+const MESSAGE = 'Jest tests should not return a value.';
+const RETURN_STATEMENT = 'ReturnStatement';
+const BLOCK_STATEMENT = 'BlockStatement';
+
+const getBody = args => {
+  if (
+    args.length > 1 &&
+    isFunction(args[1]) &&
+    args[1].body.type === BLOCK_STATEMENT
+  ) {
+    return args[1].body.body;
+  }
+  return [];
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isTestCase(node)) return;
+        const body = getBody(node.arguments);
+        const returnStmt = body.find(t => t.type === RETURN_STATEMENT);
+        if (!returnStmt) return;
+
+        context.report({
+          message: MESSAGE,
+          node: returnStmt,
+        });
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/no-truthy-falsy.js
+++ b/node_modules/eslint-plugin-jest/rules/no-truthy-falsy.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const {
+  getDocsUrl,
+  expectCase,
+  expectNotCase,
+  expectResolveCase,
+  expectRejectCase,
+  method,
+} = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          expectCase(node) ||
+          expectNotCase(node) ||
+          expectResolveCase(node) ||
+          expectRejectCase(node)
+        ) {
+          const targetNode =
+            node.parent.parent.type === 'MemberExpression' ? node.parent : node;
+
+          const methodNode = method(targetNode);
+          const { name: methodName } = methodNode;
+
+          if (methodName === 'toBeTruthy' || methodName === 'toBeFalsy') {
+            context.report({
+              data: { methodName },
+              message: 'Avoid {{methodName}}',
+              node: methodNode,
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/prefer-called-with.js
+++ b/node_modules/eslint-plugin-jest/rules/prefer-called-with.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { getDocsUrl, expectCase, expectNotCase, method } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        // Could check resolves/rejects here but not a likely idiom.
+        if (expectCase(node) && !expectNotCase(node)) {
+          const methodNode = method(node);
+          const { name } = methodNode;
+          if (name === 'toBeCalled' || name === 'toHaveBeenCalled') {
+            context.report({
+              data: { name },
+              message: 'Prefer {{name}}With(/* expected args */)',
+              node: methodNode,
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/prefer-expect-assertions.js
+++ b/node_modules/eslint-plugin-jest/rules/prefer-expect-assertions.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const { getDocsUrl } = require('./util');
+
+const ruleMsg =
+  'Every test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression';
+
+const validateArguments = expression => {
+  return (
+    expression.arguments &&
+    expression.arguments.length === 1 &&
+    Number.isInteger(expression.arguments[0].value)
+  );
+};
+
+const isExpectAssertionsOrHasAssertionsCall = expression => {
+  try {
+    const expectAssertionOrHasAssertionCall =
+      expression.type === 'CallExpression' &&
+      expression.callee.type === 'MemberExpression' &&
+      expression.callee.object.name === 'expect' &&
+      (expression.callee.property.name === 'assertions' ||
+        expression.callee.property.name === 'hasAssertions');
+
+    if (expression.callee.property.name === 'assertions') {
+      return expectAssertionOrHasAssertionCall && validateArguments(expression);
+    }
+    return expectAssertionOrHasAssertionCall;
+  } catch (e) {
+    return false;
+  }
+};
+
+const getFunctionFirstLine = functionBody => {
+  return functionBody[0] && functionBody[0].expression;
+};
+
+const isFirstLineExprStmt = functionBody => {
+  return functionBody[0] && functionBody[0].type === 'ExpressionStatement';
+};
+
+const reportMsg = (context, node) => {
+  context.report({
+    message: ruleMsg,
+    node,
+  });
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      'CallExpression[callee.name=/^(it|test)$/][arguments.1.body.body]'(node) {
+        const testFuncBody = node.arguments[1].body.body;
+
+        if (!isFirstLineExprStmt(testFuncBody)) {
+          reportMsg(context, node);
+        } else {
+          const testFuncFirstLine = getFunctionFirstLine(testFuncBody);
+          if (!isExpectAssertionsOrHasAssertionsCall(testFuncFirstLine)) {
+            reportMsg(context, node);
+          }
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/prefer-inline-snapshots.js
+++ b/node_modules/eslint-plugin-jest/rules/prefer-inline-snapshots.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { getDocsUrl } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const propertyName = node.callee.property && node.callee.property.name;
+        if (propertyName === 'toMatchSnapshot') {
+          context.report({
+            fix(fixer) {
+              return [
+                fixer.replaceText(
+                  node.callee.property,
+                  'toMatchInlineSnapshot'
+                ),
+              ];
+            },
+            message: 'Use toMatchInlineSnapshot() instead',
+            node: node.callee.property,
+          });
+        } else if (propertyName === 'toThrowErrorMatchingSnapshot') {
+          context.report({
+            fix(fixer) {
+              return [
+                fixer.replaceText(
+                  node.callee.property,
+                  'toThrowErrorMatchingInlineSnapshot'
+                ),
+              ];
+            },
+            message: 'Use toThrowErrorMatchingInlineSnapshot() instead',
+            node: node.callee.property,
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/prefer-spy-on.js
+++ b/node_modules/eslint-plugin-jest/rules/prefer-spy-on.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { getDocsUrl, getNodeName } = require('./util');
+
+const getJestFnCall = node => {
+  if (
+    (node.type !== 'CallExpression' && node.type !== 'MemberExpression') ||
+    (node.callee && node.callee.type !== 'MemberExpression')
+  ) {
+    return null;
+  }
+
+  const obj = node.callee ? node.callee.object : node.object;
+
+  if (obj.type === 'Identifier') {
+    return node.type === 'CallExpression' &&
+      getNodeName(node.callee) === 'jest.fn'
+      ? node
+      : null;
+  }
+
+  return getJestFnCall(obj);
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      AssignmentExpression(node) {
+        if (node.left.type !== 'MemberExpression') return;
+
+        const jestFnCall = getJestFnCall(node.right);
+
+        if (!jestFnCall) return;
+
+        context.report({
+          node,
+          message: 'Use jest.spyOn() instead.',
+          fix(fixer) {
+            const leftPropQuote =
+              node.left.property.type === 'Identifier' ? "'" : '';
+            const [arg] = jestFnCall.arguments;
+            const argSource = arg && context.getSourceCode().getText(arg);
+            const mockImplementation = argSource
+              ? `.mockImplementation(${argSource})`
+              : '';
+
+            return [
+              fixer.insertTextBefore(node.left, `jest.spyOn(`),
+              fixer.replaceTextRange(
+                [node.left.object.range[1], node.left.property.range[0]],
+                `, ${leftPropQuote}`
+              ),
+              fixer.replaceTextRange(
+                [node.left.property.range[1], jestFnCall.range[1]],
+                `${leftPropQuote})${mockImplementation}`
+              ),
+            ];
+          },
+        });
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/prefer-strict-equal.js
+++ b/node_modules/eslint-plugin-jest/rules/prefer-strict-equal.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { expectCase, getDocsUrl, method } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!expectCase(node)) {
+          return;
+        }
+
+        const propertyName = method(node) && method(node).name;
+
+        if (propertyName === 'toEqual') {
+          context.report({
+            fix(fixer) {
+              return [fixer.replaceText(method(node), 'toStrictEqual')];
+            },
+            message: 'Use toStrictEqual() instead',
+            node: method(node),
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/prefer-to-be-null.js
+++ b/node_modules/eslint-plugin-jest/rules/prefer-to-be-null.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const {
+  getDocsUrl,
+  argument,
+  argument2,
+  expectToBeCase,
+  expectToEqualCase,
+  expectNotToEqualCase,
+  expectNotToBeCase,
+  method,
+  method2,
+} = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const is = expectToBeCase(node, null) || expectToEqualCase(node, null);
+        const isNot =
+          expectNotToEqualCase(node, null) || expectNotToBeCase(node, null);
+
+        if (is || isNot) {
+          context.report({
+            fix(fixer) {
+              if (is) {
+                return [
+                  fixer.replaceText(method(node), 'toBeNull'),
+                  fixer.remove(argument(node)),
+                ];
+              }
+              return [
+                fixer.replaceText(method2(node), 'toBeNull'),
+                fixer.remove(argument2(node)),
+              ];
+            },
+            message: 'Use toBeNull() instead',
+            node: is ? method(node) : method2(node),
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/prefer-to-be-undefined.js
+++ b/node_modules/eslint-plugin-jest/rules/prefer-to-be-undefined.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const {
+  argument,
+  argument2,
+  expectToBeCase,
+  expectNotToBeCase,
+  expectToEqualCase,
+  expectNotToEqualCase,
+  getDocsUrl,
+  method,
+  method2,
+} = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const is =
+          expectToBeCase(node, undefined) || expectToEqualCase(node, undefined);
+        const isNot =
+          expectNotToEqualCase(node, undefined) ||
+          expectNotToBeCase(node, undefined);
+
+        if (is || isNot) {
+          context.report({
+            fix(fixer) {
+              if (is) {
+                return [
+                  fixer.replaceText(method(node), 'toBeUndefined'),
+                  fixer.remove(argument(node)),
+                ];
+              }
+              return [
+                fixer.replaceText(method2(node), 'toBeUndefined'),
+                fixer.remove(argument2(node)),
+              ];
+            },
+            message: 'Use toBeUndefined() instead',
+            node: is ? method(node) : method2(node),
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/prefer-to-contain.js
+++ b/node_modules/eslint-plugin-jest/rules/prefer-to-contain.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const {
+  getDocsUrl,
+  expectCase,
+  expectResolveCase,
+  expectRejectCase,
+  method,
+  argument,
+} = require('./util');
+
+const isEqualityCheck = node =>
+  method(node) &&
+  (method(node).name === 'toBe' || method(node).name === 'toEqual');
+
+const isArgumentValid = node =>
+  argument(node).value === true || argument(node).value === false;
+
+const hasOneArgument = node => node.arguments && node.arguments.length === 1;
+
+const isValidEqualityCheck = node =>
+  isEqualityCheck(node) &&
+  hasOneArgument(node.parent.parent) &&
+  isArgumentValid(node);
+
+const isEqualityNegation = node =>
+  method(node).name === 'not' && isValidEqualityCheck(node.parent);
+
+const hasIncludesMethod = node =>
+  node.arguments[0] &&
+  node.arguments[0].callee &&
+  node.arguments[0].callee.property &&
+  node.arguments[0].callee.property.name === 'includes';
+
+const isValidIncludesMethod = node =>
+  hasIncludesMethod(node) && hasOneArgument(node.arguments[0]);
+
+const getNegationFixes = (node, sourceCode, fixer) => {
+  const negationPropertyDot = sourceCode.getFirstTokenBetween(
+    node.parent.object,
+    node.parent.property,
+    token => token.value === '.'
+  );
+  const toContainFunc =
+    isEqualityNegation(node) && argument(node.parent).value
+      ? 'not.toContain'
+      : 'toContain';
+
+  //.includes function argument
+  const [containArg] = node.arguments[0].arguments;
+  return [
+    fixer.remove(negationPropertyDot),
+    fixer.remove(method(node)),
+    fixer.replaceText(method(node.parent), toContainFunc),
+    fixer.replaceText(argument(node.parent), sourceCode.getText(containArg)),
+  ];
+};
+
+const getCommonFixes = (node, sourceCode, fixer) => {
+  const [containArg] = node.arguments[0].arguments;
+  const includesCaller = node.arguments[0].callee;
+
+  const propertyDot = sourceCode.getFirstTokenBetween(
+    includesCaller.object,
+    includesCaller.property,
+    token => token.value === '.'
+  );
+
+  const closingParenthesis = sourceCode.getTokenAfter(containArg);
+  const openParenthesis = sourceCode.getTokenBefore(containArg);
+
+  return [
+    fixer.remove(containArg),
+    fixer.remove(includesCaller.property),
+    fixer.remove(propertyDot),
+    fixer.remove(closingParenthesis),
+    fixer.remove(openParenthesis),
+  ];
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          !(expectResolveCase(node) || expectRejectCase(node)) &&
+          expectCase(node) &&
+          (isEqualityNegation(node) || isValidEqualityCheck(node)) &&
+          isValidIncludesMethod(node)
+        ) {
+          context.report({
+            fix(fixer) {
+              const sourceCode = context.getSourceCode();
+
+              let fixArr = getCommonFixes(node, sourceCode, fixer);
+              if (isEqualityNegation(node)) {
+                return getNegationFixes(node, sourceCode, fixer).concat(fixArr);
+              }
+
+              const toContainFunc = argument(node).value
+                ? 'toContain'
+                : 'not.toContain';
+
+              //.includes function argument
+              const [containArg] = node.arguments[0].arguments;
+
+              fixArr.push(fixer.replaceText(method(node), toContainFunc));
+              fixArr.push(
+                fixer.replaceText(
+                  argument(node),
+                  sourceCode.getText(containArg)
+                )
+              );
+              return fixArr;
+            },
+            message: 'Use toContain() instead',
+            node: method(node),
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/prefer-to-have-length.js
+++ b/node_modules/eslint-plugin-jest/rules/prefer-to-have-length.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const {
+  getDocsUrl,
+  expectCase,
+  expectNotCase,
+  expectResolveCase,
+  expectRejectCase,
+  method,
+} = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          !(
+            expectNotCase(node) ||
+            expectResolveCase(node) ||
+            expectRejectCase(node)
+          ) &&
+          expectCase(node) &&
+          (method(node).name === 'toBe' || method(node).name === 'toEqual') &&
+          node.arguments[0].property &&
+          node.arguments[0].property.name === 'length'
+        ) {
+          const propertyDot = context
+            .getSourceCode()
+            .getFirstTokenBetween(
+              node.arguments[0].object,
+              node.arguments[0].property,
+              token => token.value === '.'
+            );
+          context.report({
+            fix(fixer) {
+              return [
+                fixer.remove(propertyDot),
+                fixer.remove(node.arguments[0].property),
+                fixer.replaceText(method(node), 'toHaveLength'),
+              ];
+            },
+            message: 'Use toHaveLength() instead',
+            node: method(node),
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/prefer-todo.js
+++ b/node_modules/eslint-plugin-jest/rules/prefer-todo.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const {
+  getDocsUrl,
+  isFunction,
+  composeFixers,
+  getNodeName,
+  isString,
+} = require('./util');
+
+function isOnlyTestTitle(node) {
+  return node.arguments.length === 1;
+}
+
+function isFunctionBodyEmpty(node) {
+  return node.body.body && !node.body.body.length;
+}
+
+function isTestBodyEmpty(node) {
+  const fn = node.arguments[1]; // eslint-disable-line prefer-destructuring
+  return fn && isFunction(fn) && isFunctionBodyEmpty(fn);
+}
+
+function addTodo(node, fixer) {
+  const testName = getNodeName(node.callee)
+    .split('.')
+    .shift();
+  return fixer.replaceText(node.callee, `${testName}.todo`);
+}
+
+function removeSecondArg({ arguments: [first, second] }, fixer) {
+  return fixer.removeRange([first.range[1], second.range[1]]);
+}
+
+function isFirstArgString({ arguments: [firstArg] }) {
+  return firstArg && isString(firstArg);
+}
+
+const isTestCase = node =>
+  node &&
+  node.type === 'CallExpression' &&
+  ['it', 'test', 'it.skip', 'test.skip'].includes(getNodeName(node.callee));
+
+function create(context) {
+  return {
+    CallExpression(node) {
+      if (isTestCase(node) && isFirstArgString(node)) {
+        const combineFixers = composeFixers(node);
+
+        if (isTestBodyEmpty(node)) {
+          context.report({
+            message: 'Prefer todo test case over empty test case',
+            node,
+            fix: combineFixers(removeSecondArg, addTodo),
+          });
+        }
+
+        if (isOnlyTestTitle(node)) {
+          context.report({
+            message: 'Prefer todo test case over unimplemented test case',
+            node,
+            fix: combineFixers(addTodo),
+          });
+        }
+      }
+    },
+  };
+}
+
+module.exports = {
+  create,
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/require-tothrow-message.js
+++ b/node_modules/eslint-plugin-jest/rules/require-tothrow-message.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { argument, expectCase, getDocsUrl, method } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!expectCase(node)) {
+          return;
+        }
+
+        const propertyName = method(node) && method(node).name;
+
+        // Look for `toThrow` calls with no arguments.
+        if (
+          ['toThrow', 'toThrowError'].includes(propertyName) &&
+          !argument(node)
+        ) {
+          context.report({
+            message: `Add an error message to {{ propertyName }}()`,
+            data: {
+              propertyName,
+            },
+            node: method(node),
+          });
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/util.js
+++ b/node_modules/eslint-plugin-jest/rules/util.js
@@ -1,0 +1,228 @@
+'use strict';
+
+const path = require('path');
+const { version } = require('../package.json');
+
+const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';
+
+const expectCase = node =>
+  node.callee.name === 'expect' &&
+  node.arguments.length === 1 &&
+  node.parent &&
+  node.parent.type === 'MemberExpression' &&
+  node.parent.parent;
+
+const expectNotCase = node =>
+  expectCase(node) &&
+  node.parent.parent.type === 'MemberExpression' &&
+  methodName(node) === 'not';
+
+const expectResolveCase = node =>
+  expectCase(node) &&
+  node.parent.parent.type === 'MemberExpression' &&
+  methodName(node) === 'resolve';
+
+const expectRejectCase = node =>
+  expectCase(node) &&
+  node.parent.parent.type === 'MemberExpression' &&
+  methodName(node) === 'reject';
+
+const expectToBeCase = (node, arg) =>
+  !(expectNotCase(node) || expectResolveCase(node) || expectRejectCase(node)) &&
+  expectCase(node) &&
+  methodName(node) === 'toBe' &&
+  argument(node) &&
+  ((argument(node).type === 'Literal' &&
+    argument(node).value === null &&
+    arg === null) ||
+    (argument(node).name === 'undefined' && arg === undefined));
+
+const expectNotToBeCase = (node, arg) =>
+  expectNotCase(node) &&
+  methodName2(node) === 'toBe' &&
+  argument2(node) &&
+  ((argument2(node).type === 'Literal' &&
+    argument2(node).value === null &&
+    arg === null) ||
+    (argument2(node).name === 'undefined' && arg === undefined));
+
+const expectToEqualCase = (node, arg) =>
+  !(expectNotCase(node) || expectResolveCase(node) || expectRejectCase(node)) &&
+  expectCase(node) &&
+  methodName(node) === 'toEqual' &&
+  argument(node) &&
+  ((argument(node).type === 'Literal' &&
+    argument(node).value === null &&
+    arg === null) ||
+    (argument(node).name === 'undefined' && arg === undefined));
+
+const expectNotToEqualCase = (node, arg) =>
+  expectNotCase(node) &&
+  methodName2(node) === 'toEqual' &&
+  argument2(node) &&
+  ((argument2(node).type === 'Literal' &&
+    argument2(node).value === null &&
+    arg === null) ||
+    (argument2(node).name === 'undefined' && arg === undefined));
+
+const method = node => node.parent.property;
+
+const method2 = node => node.parent.parent.property;
+
+const methodName = node => method(node).name;
+
+const methodName2 = node => method2(node).name;
+
+const argument = node =>
+  node.parent.parent.arguments && node.parent.parent.arguments[0];
+
+const argument2 = node =>
+  node.parent.parent.parent.arguments && node.parent.parent.parent.arguments[0];
+
+const describeAliases = Object.assign(Object.create(null), {
+  describe: true,
+  'describe.only': true,
+  'describe.skip': true,
+  fdescribe: true,
+  xdescribe: true,
+});
+
+const testCaseNames = Object.assign(Object.create(null), {
+  fit: true,
+  it: true,
+  'it.only': true,
+  'it.skip': true,
+  test: true,
+  'test.only': true,
+  'test.skip': true,
+  xit: true,
+  xtest: true,
+});
+
+const getNodeName = node => {
+  function joinNames(a, b) {
+    return a && b ? `${a}.${b}` : null;
+  }
+
+  switch (node && node.type) {
+    case 'Identifier':
+      return node.name;
+    case 'Literal':
+      return node.value;
+    case 'TemplateLiteral':
+      if (node.expressions.length === 0) return node.quasis[0].value.cooked;
+      break;
+    case 'MemberExpression':
+      return joinNames(getNodeName(node.object), getNodeName(node.property));
+  }
+
+  return null;
+};
+
+const isTestCase = node =>
+  node &&
+  node.type === 'CallExpression' &&
+  testCaseNames[getNodeName(node.callee)];
+
+const isDescribe = node =>
+  node.type === 'CallExpression' && describeAliases[getNodeName(node.callee)];
+
+const isFunction = node =>
+  node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression';
+
+const isString = node =>
+  (node.type === 'Literal' && typeof node.value === 'string') ||
+  isTemplateLiteral(node);
+
+const isTemplateLiteral = node => node.type === 'TemplateLiteral';
+
+const hasExpressions = node => node.expressions && node.expressions.length > 0;
+
+const getStringValue = arg =>
+  isTemplateLiteral(arg) ? arg.quasis[0].value.raw : arg.value;
+
+/**
+ * Generates the URL to documentation for the given rule name. It uses the
+ * package version to build the link to a tagged version of the
+ * documentation file.
+ *
+ * @param {string} filename - Name of the eslint rule
+ * @returns {string} URL to the documentation for the given rule
+ */
+const getDocsUrl = filename => {
+  const ruleName = path.basename(filename, '.js');
+
+  return `${REPO_URL}/blob/v${version}/docs/rules/${ruleName}.md`;
+};
+
+const collectReferences = scope => {
+  const locals = new Set();
+  const unresolved = new Set();
+
+  let currentScope = scope;
+
+  while (currentScope !== null) {
+    for (const ref of currentScope.variables) {
+      const isReferenceDefined = ref.defs.some(def => {
+        return def.type !== 'ImplicitGlobalVariable';
+      });
+
+      if (isReferenceDefined) {
+        locals.add(ref.name);
+      }
+    }
+
+    for (const ref of currentScope.through) {
+      unresolved.add(ref.identifier.name);
+    }
+
+    currentScope = currentScope.upper;
+  }
+
+  return { locals, unresolved };
+};
+
+const scopeHasLocalReference = (scope, referenceName) => {
+  const references = collectReferences(scope);
+  return (
+    // referenceName was found as a local variable or function declaration.
+    references.locals.has(referenceName) ||
+    // referenceName was not found as an unresolved reference,
+    // meaning it is likely not an implicit global reference.
+    !references.unresolved.has(referenceName)
+  );
+};
+
+function composeFixers(node) {
+  return (...fixers) => {
+    return fixerApi => {
+      return fixers.reduce((all, fixer) => [...all, fixer(node, fixerApi)], []);
+    };
+  };
+}
+
+module.exports = {
+  method,
+  method2,
+  argument,
+  argument2,
+  expectCase,
+  expectNotCase,
+  expectResolveCase,
+  expectRejectCase,
+  expectToBeCase,
+  expectNotToBeCase,
+  expectToEqualCase,
+  expectNotToEqualCase,
+  getNodeName,
+  getStringValue,
+  isDescribe,
+  isFunction,
+  isTemplateLiteral,
+  isTestCase,
+  isString,
+  hasExpressions,
+  getDocsUrl,
+  scopeHasLocalReference,
+  composeFixers,
+};

--- a/node_modules/eslint-plugin-jest/rules/valid-describe.js
+++ b/node_modules/eslint-plugin-jest/rules/valid-describe.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const { getDocsUrl, isDescribe, isFunction } = require('./util');
+
+const isAsync = node => node.async;
+
+const isString = node =>
+  (node.type === 'Literal' && typeof node.value === 'string') ||
+  node.type === 'TemplateLiteral';
+
+const hasParams = node => node.params.length > 0;
+
+const paramsLocation = params => {
+  const [first] = params;
+  const last = params[params.length - 1];
+  return {
+    start: {
+      line: first.loc.start.line,
+      column: first.loc.start.column,
+    },
+    end: {
+      line: last.loc.end.line,
+      column: last.loc.end.column,
+    },
+  };
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (isDescribe(node)) {
+          if (node.arguments.length === 0) {
+            return context.report({
+              message: 'Describe requires name and callback arguments',
+              loc: node.loc,
+            });
+          }
+
+          const [name] = node.arguments;
+          const [, callbackFunction] = node.arguments;
+          if (!isString(name)) {
+            context.report({
+              message: 'First argument must be name',
+              loc: paramsLocation(node.arguments),
+            });
+          }
+          if (callbackFunction === undefined) {
+            return context.report({
+              message: 'Describe requires name and callback arguments',
+              loc: paramsLocation(node.arguments),
+            });
+          }
+          if (!isFunction(callbackFunction)) {
+            return context.report({
+              message: 'Second argument must be function',
+              loc: paramsLocation(node.arguments),
+            });
+          }
+          if (isAsync(callbackFunction)) {
+            context.report({
+              message: 'No async describe callback',
+              node: callbackFunction,
+            });
+          }
+          if (hasParams(callbackFunction)) {
+            context.report({
+              message: 'Unexpected argument(s) in describe callback',
+              loc: paramsLocation(callbackFunction.params),
+            });
+          }
+          if (callbackFunction.body.type === 'BlockStatement') {
+            callbackFunction.body.body.forEach(node => {
+              if (node.type === 'ReturnStatement') {
+                context.report({
+                  message: 'Unexpected return statement in describe callback',
+                  node,
+                });
+              }
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/valid-expect-in-promise.js
+++ b/node_modules/eslint-plugin-jest/rules/valid-expect-in-promise.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const { getDocsUrl, isFunction } = require('./util');
+
+const reportMsg =
+  'Promise should be returned to test its fulfillment or rejection';
+
+const isThenOrCatch = node => {
+  return (
+    node.property &&
+    (node.property.name === 'then' || node.property.name === 'catch')
+  );
+};
+
+const isExpectCallPresentInFunction = body => {
+  if (body.type === 'BlockStatement') {
+    return body.body.find(line => {
+      if (line.type === 'ExpressionStatement')
+        return isExpectCall(line.expression);
+      if (line.type === 'ReturnStatement') return isExpectCall(line.argument);
+    });
+  } else {
+    return isExpectCall(body);
+  }
+};
+
+const isExpectCall = expression => {
+  return (
+    expression &&
+    expression.type === 'CallExpression' &&
+    expression.callee.type === 'MemberExpression' &&
+    expression.callee.object.type === 'CallExpression' &&
+    expression.callee.object.callee.name === 'expect'
+  );
+};
+
+const reportReturnRequired = (context, node) => {
+  context.report({
+    loc: {
+      end: {
+        column: node.parent.parent.loc.end.column,
+        line: node.parent.parent.loc.end.line,
+      },
+      start: node.parent.parent.loc.start,
+    },
+    message: reportMsg,
+    node,
+  });
+};
+
+const isPromiseReturnedLater = (node, testFunctionBody) => {
+  let promiseName;
+  if (node.parent.parent.type === 'ExpressionStatement') {
+    promiseName = node.parent.parent.expression.callee.object.name;
+  } else if (node.parent.parent.type === 'VariableDeclarator') {
+    promiseName = node.parent.parent.id.name;
+  }
+  const lastLineInTestFunc = testFunctionBody[testFunctionBody.length - 1];
+  return (
+    lastLineInTestFunc.type === 'ReturnStatement' &&
+    lastLineInTestFunc.argument.name === promiseName
+  );
+};
+
+const isTestFunc = node => {
+  return (
+    node.type === 'CallExpression' &&
+    (node.callee.name === 'it' || node.callee.name === 'test')
+  );
+};
+
+const getFunctionBody = func => {
+  if (func.body.type === 'BlockStatement') return func.body.body;
+  return func.body; //arrow-short-hand-fn
+};
+
+const getTestFunction = node => {
+  let { parent } = node;
+  while (parent) {
+    if (isFunction(parent) && isTestFunc(parent.parent)) {
+      return parent;
+    }
+    parent = parent.parent;
+  }
+};
+
+const isParentThenOrPromiseReturned = (node, testFunctionBody) => {
+  return (
+    testFunctionBody.type === 'CallExpression' ||
+    testFunctionBody.type === 'NewExpression' ||
+    node.parent.parent.type === 'ReturnStatement' ||
+    isPromiseReturnedLater(node, testFunctionBody) ||
+    isThenOrCatch(node.parent.parent)
+  );
+};
+
+const verifyExpectWithReturn = (
+  promiseCallbacks,
+  node,
+  context,
+  testFunctionBody
+) => {
+  promiseCallbacks.some(promiseCallback => {
+    if (promiseCallback && isFunction(promiseCallback)) {
+      if (
+        isExpectCallPresentInFunction(promiseCallback.body) &&
+        !isParentThenOrPromiseReturned(node, testFunctionBody)
+      ) {
+        reportReturnRequired(context, node);
+        return true;
+      }
+    }
+  });
+};
+
+const isAwaitExpression = node => {
+  return node.parent.parent && node.parent.parent.type === 'AwaitExpression';
+};
+
+const isHavingAsyncCallBackParam = testFunction => {
+  try {
+    return testFunction.params[0].type === 'Identifier';
+  } catch (e) {
+    return false;
+  }
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (
+          node.type === 'MemberExpression' &&
+          isThenOrCatch(node) &&
+          node.parent.type === 'CallExpression' &&
+          !isAwaitExpression(node)
+        ) {
+          const testFunction = getTestFunction(node);
+          if (testFunction && !isHavingAsyncCallBackParam(testFunction)) {
+            const testFunctionBody = getFunctionBody(testFunction);
+            const [
+              fulfillmentCallback,
+              rejectionCallback,
+            ] = node.parent.arguments;
+
+            // then block can have two args, fulfillment & rejection
+            // then block can have one args, fulfillment
+            // catch block can have one args, rejection
+            // ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+            verifyExpectWithReturn(
+              [fulfillmentCallback, rejectionCallback],
+              node,
+              context,
+              testFunctionBody
+            );
+          }
+        }
+      },
+    };
+  },
+};

--- a/node_modules/eslint-plugin-jest/rules/valid-expect.js
+++ b/node_modules/eslint-plugin-jest/rules/valid-expect.js
@@ -1,0 +1,130 @@
+'use strict';
+
+/*
+ * This implementation is ported from from eslint-plugin-jasmine.
+ * MIT license, Tom Vincent.
+ */
+
+const { getDocsUrl } = require('./util');
+
+const expectProperties = ['not', 'resolves', 'rejects'];
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const calleeName = node.callee.name;
+
+        if (calleeName === 'expect') {
+          // checking "expect()" arguments
+          if (node.arguments.length > 1) {
+            const secondArgumentLocStart = node.arguments[1].loc.start;
+            const lastArgumentLocEnd =
+              node.arguments[node.arguments.length - 1].loc.end;
+
+            context.report({
+              loc: {
+                end: {
+                  column: lastArgumentLocEnd.column - 1,
+                  line: lastArgumentLocEnd.line,
+                },
+                start: secondArgumentLocStart,
+              },
+              message: 'More than one argument was passed to expect().',
+              node,
+            });
+          } else if (node.arguments.length === 0) {
+            const expectLength = calleeName.length;
+            context.report({
+              loc: {
+                end: {
+                  column: node.loc.start.column + expectLength + 1,
+                  line: node.loc.start.line,
+                },
+                start: {
+                  column: node.loc.start.column + expectLength,
+                  line: node.loc.start.line,
+                },
+              },
+              message: 'No arguments were passed to expect().',
+              node,
+            });
+          }
+
+          // something was called on `expect()`
+          if (
+            node.parent &&
+            node.parent.type === 'MemberExpression' &&
+            node.parent.parent
+          ) {
+            let parentNode = node.parent;
+            let parentProperty = parentNode.property;
+            let propertyName = parentProperty.name;
+            let grandParent = parentNode.parent;
+
+            // a property is accessed, get the next node
+            if (grandParent.type === 'MemberExpression') {
+              // a modifier is used, just get the next one
+              if (expectProperties.indexOf(propertyName) > -1) {
+                grandParent = grandParent.parent;
+              } else {
+                // only a few properties are allowed
+                context.report({
+                  // For some reason `endColumn` isn't set in tests if `loc` is
+                  // not added
+                  loc: parentProperty.loc,
+                  message: `"${propertyName}" is not a valid property of expect.`,
+                  node: parentProperty,
+                });
+              }
+
+              // this next one should be the matcher
+              parentNode = parentNode.parent;
+              parentProperty = parentNode.property;
+              propertyName = parentProperty.name;
+            }
+
+            // matcher was not called
+            if (grandParent.type === 'ExpressionStatement') {
+              let message;
+              if (expectProperties.indexOf(propertyName) > -1) {
+                message = `"${propertyName}" needs to call a matcher.`;
+              } else {
+                message = `"${propertyName}" was not called.`;
+              }
+
+              context.report({
+                // For some reason `endColumn` isn't set in tests if `loc` is not
+                // added
+                loc: parentProperty.loc,
+                message,
+                node: parentProperty,
+              });
+            }
+          }
+        }
+      },
+
+      // nothing called on "expect()"
+      'CallExpression:exit'(node) {
+        if (
+          node.callee.name === 'expect' &&
+          node.parent.type === 'ExpressionStatement'
+        ) {
+          context.report({
+            // For some reason `endColumn` isn't set in tests if `loc` is not
+            // added
+            loc: node.loc,
+            message: 'No assertion was called on expect().',
+            node,
+          });
+        }
+      },
+    };
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -598,6 +598,12 @@
         "lodash": "^4.11.1"
       }
     },
+    "eslint-plugin-jest": {
+      "version": "22.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.5.1.tgz",
+      "integrity": "sha512-c3WjZR/HBoi4GedJRwo2OGHa8Pzo1EbSVwQ2HFzJ+4t2OoYM7Alx646EH/aaxZ+9eGcPiq0FT0UGkRuFFx2FHg==",
+      "dev": true
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "khan-lesshint": "0.1.0",
     "prettier": "1.15.1",
     "utf8": "3.0.0"
+  },
+  "devDependencies": {
+    "eslint-plugin-jest": "^22.5.1"
   }
 }


### PR DESCRIPTION
We'd like to use eslint-plugin-jest to enforce some basic rules such
as no duplicate test titles, no empty tests (prefer-todo), etc.  This
diff adds the plugin.  The rules themselves are added to webapp only
in [D54481](https://phabricator.khanacademy.org/D54481).

Test Plan: n/a