### PR TITLE
Add @khanacademy/eslint-plugin

### DIFF
--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -6,6 +6,8 @@
   "flags": [],
   "linkedModules": [
     "@khanacademy/babel-plugin-vite",
+    "@khanacademy/eslint-plugin",
+    "@khanacademy/eslint-plugin-khan",
     "@khanacademy/jest-environment-vite",
     "@khanacademy/vite-server",
     "@khanacademy/wonder-blocks-dropdown",
@@ -16,6 +18,7 @@
     "babel-plugin-flow-react-proptypes",
     "babel-plugin-vite",
     "dendro",
+    "eslint-plugin-khan",
     "flow-coverage-report",
     "jest-canvas-mock",
     "jest-environment-vite",
@@ -25,6 +28,7 @@
     "wonder-blocks"
   ],
   "topLevelPatterns": [
+    "@khanacademy/eslint-plugin@^0.2.1",
     "babel-eslint@10.0.1",
     "eslint-config-prettier@3.1.0",
     "eslint-plugin-babel@^5.3.0",
@@ -59,6 +63,7 @@
     "@babel/traverse@^7.0.0": "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216",
     "@babel/types@^7.0.0": "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0",
     "@babel/types@^7.4.4": "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0",
+    "@khanacademy/eslint-plugin@^0.2.1": "https://registry.yarnpkg.com/@khanacademy/eslint-plugin/-/eslint-plugin-0.2.1.tgz#fc1d6ee0b34ab79a244c445fe4c40631e1974b48",
     "acorn-jsx@^5.0.0": "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e",
     "acorn@^6.0.2": "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f",
     "ajv@^4.9.1": "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536",

--- a/node_modules/@khanacademy/eslint-plugin/.arcconfig
+++ b/node_modules/@khanacademy/eslint-plugin/.arcconfig
@@ -1,0 +1,5 @@
+{
+    "project_id": "eslint-plugin-khan",
+    "conduit_uri": "https://phabricator.khanacademy.org/",
+    "lint.engine": "ArcanistConfigurationDrivenLintEngine"
+}

--- a/node_modules/@khanacademy/eslint-plugin/.arclint
+++ b/node_modules/@khanacademy/eslint-plugin/.arclint
@@ -1,0 +1,9 @@
+{
+  "linters": {
+    "khan-linter": {
+      "type": "script-and-regex",
+      "script-and-regex.script": "ka-lint --always-exit-0 --blacklist=yes --propose-arc-fixes",
+      "script-and-regex.regex": "\/^((?P<file>[^:]*):(?P<line>\\d+):((?P<char>\\d+):)? (?P<name>((?P<error>E)|(?P<warning>W))\\S+) (?P<message>[^\\x00\n]*)(\\x00(?P<original>[^\\x00]*)\\x00(?P<replacement>[^\\x00]*)\\x00)?)|(?P<ignore>SKIPPING.*)$\/m"
+    }
+  }
+}

--- a/node_modules/@khanacademy/eslint-plugin/.prettierignore
+++ b/node_modules/@khanacademy/eslint-plugin/.prettierignore
@@ -1,0 +1,2 @@
+*.md
+package.json

--- a/node_modules/@khanacademy/eslint-plugin/.prettierrc
+++ b/node_modules/@khanacademy/eslint-plugin/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "trailingComma": "all",
+    "tabWidth": 4,
+    "semi": true,
+    "singleQuote": false,
+    "bracketSpacing": false
+}

--- a/node_modules/@khanacademy/eslint-plugin/.travis.yml
+++ b/node_modules/@khanacademy/eslint-plugin/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "node"
+notifications:
+  email: false
+script:
+  - npm test

--- a/node_modules/@khanacademy/eslint-plugin/LICENSE
+++ b/node_modules/@khanacademy/eslint-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Khan Academy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/@khanacademy/eslint-plugin/README.md
+++ b/node_modules/@khanacademy/eslint-plugin/README.md
@@ -1,0 +1,12 @@
+# eslint-plugin-khan
+
+[![Build Status](https://travis-ci.org/Khan/eslint-plugin-khan.svg?branch=master)](https://travis-ci.org/Khan/eslint-plugin-khan)
+
+eslint plugin with our set of custom rules for various things
+
+## Rules
+
+- [khan/flow-array-type-style](docs/flow-array-type-style.md)
+- [khan/flow-no-one-tuple](docs/flow-no-one-tuple.md)
+- [khan/imports-requiring-flow](docs/imports-requiring-flow.md)
+- [khan/react-no-subscriptions-before-mount](docs/react-no-subscriptions-before-mount.md)

--- a/node_modules/@khanacademy/eslint-plugin/docs/flow-array-type-style.md
+++ b/node_modules/@khanacademy/eslint-plugin/docs/flow-array-type-style.md
@@ -1,0 +1,29 @@
+# Prefer generic style array types in flow (flow-array-type-style)
+
+In flow, array types can be written as `T[]` or `Array<T>`.  When the type is
+nullable, the former can be consfusing, e.g.
+
+```
+?T[] = ?Array<T>
+(?T)[] = Array<?T>
+```
+
+This rule prefers the `Array<T>` for array types to avoid the confusion.
+
+## Rule Details
+
+The following are considered warnings:
+
+```js
+type foo = number[]
+type foo = ?number[]
+type foo = (?number)[]
+```
+
+The following are not considered warnings:
+
+```js
+type foo = Array<number>
+type foo = ?Array<number>
+type foo = Array<?number>
+```

--- a/node_modules/@khanacademy/eslint-plugin/docs/flow-no-one-tuple.md
+++ b/node_modules/@khanacademy/eslint-plugin/docs/flow-no-one-tuple.md
@@ -1,0 +1,33 @@
+# Disallow one-tuples in flow (flow-no-one-tuple)
+
+A common mistake people make, when starting to use Flow, is to assume that
+arrays of a type can be expressed by wrapping the type in brackets (eg.
+`[number]`).
+
+This expression _actually_ refers to a tuple, which is an array that holds a
+finite number of items, each with their type specified. The correct expression
+would be `Array<number>`.
+
+To help avoid this mistake, we warn against the uncommon pattern of a
+single-value tuple.
+
+## Rule Details
+
+The following are considered warnings:
+
+```js
+type foo = [number]
+```
+
+The following are not considered warnings:
+
+```js
+type foo = Array<number>
+type foo = [number, number]
+```
+
+If you actually need a one-tuple, the rule can be disabled, e.g.
+
+```js
+type foo = [number]  // eslint-disable-line flow-no-one-tuple
+```

--- a/node_modules/@khanacademy/eslint-plugin/docs/imports-requiring-flow.md
+++ b/node_modules/@khanacademy/eslint-plugin/docs/imports-requiring-flow.md
@@ -1,0 +1,74 @@
+# Specify imports that require flow (imports-requiring-flow)
+
+We'd like to require the use of flow with certain modules so that we can
+rely on flow to catch issues when refactoring those modules.  This rule
+requires that any files importing one of the specified modules be using
+flow as indicated by a `// @flow` comment in the file.
+
+Notes:
+- All paths in `modules` that aren't npm packages are considered to be
+  relative to `rootDir`.
+- `rootDir` is required and should usually be set to `__dirname`.  This
+  requires the the configuration of `khan/imports-requiring-flow` to be
+  done in a `.js` file.
+
+## Rule Details
+
+Give the following rule config:
+
+```
+"khan/imports-requiring-flow": [
+    "error", {
+        rootDir: __dirname,
+        modules: ["foo", "src/bar.js"],
+    },
+]
+```
+
+The following are considered warnings:
+
+```js
+import foo from "foo";
+```
+
+```js
+import bar from "./bar";
+```
+
+```js
+const foo = require("foo");
+```
+
+```js
+const bar = require("./bar.js");
+```
+
+The following are not considered warnings:
+
+```js
+// @flow
+import foo from "foo";
+```
+
+```js
+// @flow
+import bar from "./bar";
+```
+
+```js
+// @flow
+const foo = require("foo");
+```
+
+```js
+// @flow
+const bar = require("./bar.js");
+```
+
+```js
+import baz from "./baz.js";
+```
+
+```js
+const qux = require("qux");
+```

--- a/node_modules/@khanacademy/eslint-plugin/docs/react-no-subscriptions-before-mount.md
+++ b/node_modules/@khanacademy/eslint-plugin/docs/react-no-subscriptions-before-mount.md
@@ -1,0 +1,44 @@
+# Disallow subscriptions before React components have mounted (react-no-subscriptions-before-mount)
+
+React components should avoid doing any sort of async work (data fetching,
+event listeners, timeouts, etc) before the component has mounted.
+
+There are two main reasons for this:
+
+- We want to avoid these subscriptions on the server
+- Starting in React 16, `componentWillMount` may be called multiple times
+per mount.
+
+## Rule Details
+
+The two methods called before mount are `constructor` and `componentWillMount`.
+This rule warns for signs of async work (eg. `addEventListener`, `setTimeout`,
+`.then`)
+
+The following are considered warnings:
+
+```js
+class Foo extends Component {
+    constructor() {
+        super();
+
+        fetchData().then(...)
+    }
+}
+
+class Foo extends Component {
+    componentWillMount() {
+        window.addEventListener(...)
+    }
+}
+```
+
+The following are not considered warnings:
+
+```js
+class Foo extends Component {
+    componentDidMount() {
+        fetchData().then(...)
+    }
+}
+```

--- a/node_modules/@khanacademy/eslint-plugin/lib/index.js
+++ b/node_modules/@khanacademy/eslint-plugin/lib/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+    rules: {
+        "flow-array-type-style": require("./rules/flow-array-type-style.js"),
+        "flow-no-one-tuple": require("./rules/flow-no-one-tuple.js"),
+        "imports-requiring-flow": require("./rules/imports-requiring-flow.js"),
+        "react-no-subscriptions-before-mount": require("./rules/react-no-subscriptions-before-mount.js"),
+    },
+};

--- a/node_modules/@khanacademy/eslint-plugin/lib/rules/flow-array-type-style.js
+++ b/node_modules/@khanacademy/eslint-plugin/lib/rules/flow-array-type-style.js
@@ -1,0 +1,44 @@
+const message =
+    "Shorthand syntax for array types can appear ambiguous.  " +
+    "Please use the long-form: Array<>";
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Prefer Array<T> to T[]",
+            category: "flow",
+            recommended: false,
+        },
+        fixable: "code",
+        schema: [
+            {
+                enum: ["always", "never"],
+            },
+        ],
+    },
+
+    create(context) {
+        const configuration = context.options[0] || "never";
+        const sourceCode = context.getSource();
+
+        return {
+            ArrayTypeAnnotation(node) {
+                if (configuration === "always") {
+                    context.report({
+                        fix(fixer) {
+                            const type = node.elementType;
+                            const typeText = sourceCode.slice(...type.range);
+                            const replacementText = `Array<${typeText}>`;
+
+                            return fixer.replaceText(node, replacementText);
+                        },
+                        node: node,
+                        message: message,
+                    });
+                }
+            },
+        };
+    },
+
+    __message: message,
+};

--- a/node_modules/@khanacademy/eslint-plugin/lib/rules/flow-no-one-tuple.js
+++ b/node_modules/@khanacademy/eslint-plugin/lib/rules/flow-no-one-tuple.js
@@ -1,0 +1,44 @@
+const message =
+    "One-tuples can be confused with shorthand syntax for array types.  " +
+    "Using Array<> avoids this confusion.";
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Disallow one-tuple",
+            category: "flow",
+            recommended: false,
+        },
+        fixable: "code",
+        schema: [
+            {
+                enum: ["always", "never"],
+            },
+        ],
+    },
+
+    create(context) {
+        const configuration = context.options[0] || "never";
+        const sourceCode = context.getSource();
+
+        return {
+            TupleTypeAnnotation(node) {
+                if (configuration === "always" && node.types.length === 1) {
+                    context.report({
+                        fix(fixer) {
+                            const type = node.types[0];
+                            const typeText = sourceCode.slice(...type.range);
+                            const replacementText = `Array<${typeText}>`;
+
+                            return fixer.replaceText(node, replacementText);
+                        },
+                        node: node,
+                        message: message,
+                    });
+                }
+            },
+        };
+    },
+
+    __message: message,
+};

--- a/node_modules/@khanacademy/eslint-plugin/lib/rules/imports-requiring-flow.js
+++ b/node_modules/@khanacademy/eslint-plugin/lib/rules/imports-requiring-flow.js
@@ -1,0 +1,95 @@
+const path = require("path");
+
+const checkImport = (context, rootDir, importPath, node) => {
+    const modules = context.options[0].modules || [];
+
+    for (const mod of modules) {
+        if (importPath.startsWith(".")) {
+            const filename = context.getFilename();
+            const absImportPath = path.join(path.dirname(filename), importPath);
+            const absModPath = path.join(rootDir, mod);
+            if (absModPath === absImportPath) {
+                const message = `Importing "${importPath}" requires using flow.`;
+                context.report({
+                    node: node,
+                    message: message,
+                });
+                break;
+            }
+        } else {
+            if (mod === importPath) {
+                const message = `Importing "${importPath}" requires using flow.`;
+                context.report({
+                    node: node,
+                    message: message,
+                });
+                break;
+            }
+        }
+    }
+};
+
+const isRequire = ({callee}) =>
+    callee.type === "Identifier" && callee.name === "require";
+const isDynamicImport = ({callee}) => callee.type === "Import";
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Require flow when using certain imports",
+            category: "flow",
+            recommended: false,
+        },
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    modules: {
+                        type: "array",
+                        items: {
+                            type: "string",
+                        },
+                    },
+                    rootDir: {
+                        type: "string",
+                    },
+                },
+            },
+        ],
+    },
+
+    create(context) {
+        const modules = context.options[0].modules || [];
+        const rootDir = context.options[0].rootDir;
+        if (!rootDir) {
+            throw new Error("rootDir must be set");
+        }
+        const source = context.getSource();
+        const filename = context.getFilename();
+
+        let usingFlow = false;
+
+        return {
+            Program(node) {
+                usingFlow = node.comments.some(
+                    comment => comment.value.trim() === "@flow",
+                );
+            },
+            ImportDeclaration(node) {
+                if (!usingFlow) {
+                    const importPath = node.source.value;
+                    checkImport(context, rootDir, importPath, node);
+                }
+            },
+            CallExpression(node) {
+                const {arguments: args} = node;
+                if (!usingFlow && (isRequire(node) || isDynamicImport(node))) {
+                    if (args[0] && args[0].type === "Literal") {
+                        const importPath = args[0].value;
+                        checkImport(context, rootDir, importPath, node);
+                    }
+                }
+            },
+        };
+    },
+};

--- a/node_modules/@khanacademy/eslint-plugin/lib/rules/react-no-subscriptions-before-mount.js
+++ b/node_modules/@khanacademy/eslint-plugin/lib/rules/react-no-subscriptions-before-mount.js
@@ -1,0 +1,94 @@
+const message =
+    "Subscriptions (eg. event listeners) should not be set before the " +
+    "component has mounted. This is to avoid firing them on the server, " +
+    "as well as to ensure compatibility with React 16.\n\n" +
+    "Please consider moving this subscription to `componentDidMount`.";
+
+const subscriptionNames = [
+    "then",
+    "catch",
+    "addEventListener",
+    "setTimeout",
+    "setInterval",
+];
+
+const beforeMountMethods = ["constructor", "componentWillMount"];
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+module.exports = {
+    meta: {
+        docs: {
+            // eslint-disable-next-line max-len
+            description:
+                "Avoid subscriptions in `constructor` and `componentWillMount`",
+            category: "react",
+            recommended: false,
+        },
+        schema: [],
+    },
+    create(context) {
+        return {
+            CallExpression(node) {
+                // Is this a function (eg. 'setTimeout()'), or a method
+                // (eg. 'window.setTimeout()')?
+                const isMethod = node.callee.type === "MemberExpression";
+
+                // Grab the function-call bit (setTimeout)
+                const identifier = isMethod
+                    ? node.callee.property
+                    : node.callee;
+
+                // Bail early if this identifier isn't forbidden.
+                if (!subscriptionNames.includes(identifier.name)) {
+                    return;
+                }
+
+                // Are we in one of the before-mount methods?
+                // To answer this question, we need to find the ancestor
+                // MethodDefinition.
+                const ancestors = context.getAncestors(node.callee).reverse();
+                const ancestorMethodDef = ancestors.find(
+                    a => a.type === "MethodDefinition",
+                );
+
+                // If there _is_ no parent MethodDefinition, bail early.
+                // This subsciption is just fine.
+                if (!ancestorMethodDef) {
+                    return;
+                }
+
+                // Check if this is one of the pre-mount methods.
+                if (beforeMountMethods.includes(ancestorMethodDef.key.name)) {
+                    return context.report({
+                        node,
+                        message,
+                    });
+                }
+
+                // TODO (josh): We aren't currently checking for 'deep' subs.
+                // For example, we aren't catching this:
+                /*
+                    class Whatever extends Component {
+                        componentWillMount() {
+                            this.fetchData();
+                        }
+
+                        fetchData() {
+                            someApi.fetch().then(...);
+                        }
+                    }
+                */
+                // To do that, we need to find invocations of our ancestor
+                // MethodDefinition, and see if it's called from within one
+                // of the pre-mount methods.
+                //
+                // I haven't been able to figure out how to do this in a way
+                // that doesn't seem like total overkill, so I'm punting on
+                // this for now.
+            },
+        };
+    },
+    __message: message,
+};

--- a/node_modules/@khanacademy/eslint-plugin/package.json
+++ b/node_modules/@khanacademy/eslint-plugin/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@khanacademy/eslint-plugin",
+  "version": "0.2.1",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/index.js",
+  "repository": "https://github.com/Khan/eslint-plugin-khan",
+  "author": "Kevin Barabash <kevinb@khanacademy.org>",
+  "license": "MIT",
+  "devDependencies": {
+    "babel-eslint": "^10.0.3",
+    "eslint": "^5.8.0",
+    "mocha": "^3.3.0",
+    "prettier": "^1.18.2"
+  },
+  "scripts": {
+    "test": "mocha test/**/*.js",
+    "prettier": "prettier --write '{lib,test}/**/*.js'",
+    "prepublish": "npm run test && npm run prettier"
+  }
+}

--- a/node_modules/@khanacademy/eslint-plugin/test/flow-array-type-style_test.js
+++ b/node_modules/@khanacademy/eslint-plugin/test/flow-array-type-style_test.js
@@ -1,0 +1,37 @@
+const rule = require("../lib/rules/flow-array-type-style");
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const message = rule.__message;
+const errors = [message];
+
+ruleTester.run("flow-array-type-style", rule, {
+    valid: [
+        {
+            code: "type foo = { bar: Array<number> }",
+            options: ["always"],
+        },
+    ],
+    invalid: [
+        {
+            code: "type foo = { bar: number[] }",
+            options: ["always"],
+            errors: errors,
+            output: "type foo = { bar: Array<number> }",
+        },
+        {
+            code: "type foo = { bar: number[][] }",
+            options: ["always"],
+            // Two errors are reported because there are two array types,
+            // they just happen to be nested.
+            errors: [message, message],
+            // This is a partial fix.  Multiple runs of eslint --fix are needed
+            // to fix nested (in the AST) array types completely.
+            output: "type foo = { bar: Array<number>[] }",
+        },
+    ],
+});

--- a/node_modules/@khanacademy/eslint-plugin/test/flow-no-one-tuple_test.js
+++ b/node_modules/@khanacademy/eslint-plugin/test/flow-no-one-tuple_test.js
@@ -1,0 +1,41 @@
+const rule = require("../lib/rules/flow-no-one-tuple");
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const message = rule.__message;
+const errors = [message];
+
+ruleTester.run("flow-no-one-tuple", rule, {
+    valid: [
+        {
+            code: "type foo = { bar: Array<number> }",
+            options: ["always"],
+        },
+        {
+            code: "type foo = { bar: [number, number] }",
+            options: ["always"],
+        },
+    ],
+    invalid: [
+        {
+            code: "type foo = { bar: [number] }",
+            options: ["always"],
+            errors: errors,
+            output: "type foo = { bar: Array<number> }",
+        },
+        {
+            code: "type foo = { bar: [[number]] }",
+            options: ["always"],
+            // Two errors are reported because there are two one-tuples,
+            // they just happen to be nested.
+            errors: [message, message],
+            // This is a partial fix.  Multiple runs of eslint --fix are needed
+            // to fix nested 1-tuples completely.
+            output: "type foo = { bar: Array<[number]> }",
+        },
+    ],
+});

--- a/node_modules/@khanacademy/eslint-plugin/test/imports-requiring-flow_test.js
+++ b/node_modules/@khanacademy/eslint-plugin/test/imports-requiring-flow_test.js
@@ -1,0 +1,266 @@
+const path = require("path");
+
+const rule = require("../lib/rules/imports-requiring-flow");
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const message = rule.__message;
+const errors = [message];
+const rootDir = "/Users/nyancat/project";
+
+const importFooPkgFlow = `
+// @flow
+import foo from "foo";
+`;
+
+const importFooPkgNoflow = `
+// @noflow
+import foo from "foo";
+`;
+
+const importBarModFlow = `
+// @flow
+import bar from "../package-2/bar.js";
+`;
+
+const importBarModNoflow = `
+// @noflow
+import bar from "../package-2/bar.js";
+`;
+
+const requireFooPkgFlow = `
+// @flow
+const foo = require("foo");
+`;
+
+const requireFooPkgNoflow = `
+// @noflow
+const foo = require("foo");
+`;
+
+const requireBarModFlow = `
+// @flow
+const bar = require("../package-2/bar.js");
+`;
+
+const requireBarModNoflow = `
+// @noflow
+const bar = require("../package-2/bar.js");
+`;
+
+const dynamicImportFooPkgFlow = `
+// @flow
+const fooPromise = import("foo");
+`;
+
+const dynamicImportFooPkgNoflow = `
+// @noflow
+const fooPromise = import("foo");
+`;
+
+const dynamicImportBarModFlow = `
+// @flow
+const barPromise = import("../package-2/bar.js");
+`;
+
+const dynamicImportBarModNoflow = `
+// @noflow
+const barPromise = import("../package-2/bar.js");
+`;
+
+ruleTester.run("imports-requiring-flow", rule, {
+    valid: [
+        {
+            code: importFooPkgFlow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["foo"],
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: importBarModFlow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2/bar.js"],
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: requireFooPkgFlow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["foo"],
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: dynamicImportBarModFlow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2/bar.js"],
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: dynamicImportFooPkgFlow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["foo"],
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: requireBarModFlow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2/bar.js"],
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: importFooPkgNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["baz"], // isn't imported so it's okay
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: importBarModNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["baz"], // isn't imported so it's okay
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: requireFooPkgNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["baz"], // isn't imported so it's okay
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: requireBarModNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["baz"], // isn't imported so it's okay
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: dynamicImportBarModNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["baz"], // isn't imported so it's okay
+                    rootDir,
+                },
+            ],
+        },
+        {
+            code: dynamicImportFooPkgNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["baz"], // isn't imported so it's okay
+                    rootDir,
+                },
+            ],
+        },
+    ],
+    invalid: [
+        {
+            code: importFooPkgNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["foo"],
+                    rootDir,
+                },
+            ],
+            errors: ['Importing "foo" requires using flow.'],
+        },
+        {
+            code: importBarModNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2/bar.js"],
+                    rootDir,
+                },
+            ],
+            errors: ['Importing "../package-2/bar.js" requires using flow.'],
+        },
+        {
+            code: requireFooPkgNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["foo"],
+                    rootDir,
+                },
+            ],
+            errors: ['Importing "foo" requires using flow.'],
+        },
+        {
+            code: requireBarModNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2/bar.js"],
+                    rootDir,
+                },
+            ],
+            errors: ['Importing "../package-2/bar.js" requires using flow.'],
+        },
+        {
+            code: dynamicImportFooPkgNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["foo"],
+                    rootDir,
+                },
+            ],
+            errors: ['Importing "foo" requires using flow.'],
+        },
+        {
+            code: dynamicImportBarModNoflow,
+            filename: path.join(rootDir, "src/package-1/foobar.js"),
+            options: [
+                {
+                    modules: ["src/package-2/bar.js"],
+                    rootDir,
+                },
+            ],
+            errors: ['Importing "../package-2/bar.js" requires using flow.'],
+        },
+    ],
+});

--- a/node_modules/@khanacademy/eslint-plugin/test/react-no-subscriptions-before-mount_test.js
+++ b/node_modules/@khanacademy/eslint-plugin/test/react-no-subscriptions-before-mount_test.js
@@ -1,0 +1,141 @@
+const rule = require("../lib/rules/react-no-subscriptions-before-mount");
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+const message = rule.__message;
+const errors = [message];
+
+const validBecauseNoSubs = `
+class MyComponent extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            yadda: 5,
+        };
+    }
+
+    componentWillMount() {
+        console.log('Will mount!');
+    }
+}`;
+const validBecauseSubAfterMount = `
+class MyComponent extends Component {
+    componentDidMount() {
+        window.addEventListener('scroll', () => {})
+    }
+}`;
+
+const invalidBecausePromiseInConstructor = `
+class MyComponent extends Component {
+    constructor(props) {
+        super(props);
+
+        load().then(components => {
+            this.state = {
+                yadda: 5,
+            };
+        });
+    }
+}`;
+
+const invalidBecausePromiseInCWM = `
+class MyComponent extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            yadda: 5,
+        };
+    }
+
+    componentWillMount() {
+        const {load} = this.props;
+
+        load().then(components => {
+            this.setState({components});
+        });
+    }
+}`;
+
+const invalidBecauseEventListener = `
+class MyComponent extends Component {
+    componentWillMount() {
+        window.addEventListener('scroll', function() {});
+    }
+}`;
+
+const invalidBecauseSetTimeoutAsGlobal = `
+class MyComponent extends Component {
+    componentWillMount() {
+        setTimeout(function() {}, 1000);
+    }
+}`;
+
+const invalidBecauseSetTimeoutAsProperty = `
+class MyComponent extends Component {
+    componentWillMount() {
+        window.setTimeout(function() {}, 1000);
+    }
+}`;
+
+const invalidBecauseSubWithinBlock = `
+class MyComponent extends Component {
+    componentWillMount() {
+        if (this.whatever = 10) {
+            window.addEventListener('scroll', function() {});
+        }
+    }
+}`;
+
+const invalidWithNestedProperty = `
+class MyComponent extends Component {
+    componentWillMount() {
+        document.body.addEventListener('scroll', function() {});
+    }
+}`;
+
+const invalidWithinPromise = `
+class MyComponent extends Component {
+    componentWillMount() {
+        this.promise = new Promise((resolve, reject) => {
+            setTimeout(function() {}, 1000)
+        })
+    }
+}`;
+
+// TODO (josh): This example currently passes, but it should fail.
+// Once the rule is less naive, add this example to the invalid tests.
+// eslint-disable-next-line
+const TODOInvalid = `
+class MyComponent extends Component {
+    componentWillMount() {
+        this.subscribeToInfo();
+    }
+
+    subscribeToInfo() {
+        api.fetch().then(() => {
+
+        });
+    }
+}`;
+
+ruleTester.run("bind-react-methods", rule, {
+    valid: [validBecauseNoSubs, validBecauseSubAfterMount],
+
+    invalid: [
+        invalidBecausePromiseInConstructor,
+        invalidBecausePromiseInCWM,
+        invalidBecauseEventListener,
+        invalidBecauseSetTimeoutAsGlobal,
+        invalidBecauseSetTimeoutAsProperty,
+        invalidBecauseSubWithinBlock,
+        invalidWithNestedProperty,
+        invalidWithinPromise,
+        // TODOInvalid,
+    ].map(code => ({code, errors})),
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "eslint-check": "eslint --print-config eslintrc | eslint-config-prettier-check"
   },
   "dependencies": {
+    "@khanacademy/eslint-plugin": "^0.2.1",
     "babel-eslint": "10.0.1",
     "eslint": "5.8.0",
     "eslint-config-prettier": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,11 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@khanacademy/eslint-plugin@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@khanacademy/eslint-plugin/-/eslint-plugin-0.2.1.tgz#fc1d6ee0b34ab79a244c445fe4c40631e1974b48"
+  integrity sha512-GO9M27Sor0QrOmnmdwORJtpgzwn8KiS908GI1Bw7hYfLe/PvbEb9iclLdDtObx9sx0WNj65OL1QuAgZo4+mO9g==
+
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"


### PR DESCRIPTION
This diff adds our own eslint plugin with our own custom rules.
We'd like to start using the imports-requiring-flow rule right
away.  It allows us to list particular npm packages or source
modules that require an // @flow in the file requiring them.

Note: this PR can be landed without a deploy because nothing
is using `@khanacademy/eslint-plugin` yet.

**Test Plan:**
See https://github.com/Khan/eslint-plugin-khan/pull/2 for
the test plan.  The only difference is that we need to use
"@khanacademy" for the plugin name instead of "khan" in the configuration.