### PR TITLE
Update eslint-plugin-khan to 0.2.2

### DIFF
--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -28,7 +28,7 @@
     "wonder-blocks"
   ],
   "topLevelPatterns": [
-    "@khanacademy/eslint-plugin@^0.2.1",
+    "@khanacademy/eslint-plugin@^0.2.2",
     "babel-eslint@10.0.1",
     "eslint-config-prettier@3.1.0",
     "eslint-plugin-babel@^5.3.0",
@@ -63,7 +63,7 @@
     "@babel/traverse@^7.0.0": "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216",
     "@babel/types@^7.0.0": "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0",
     "@babel/types@^7.4.4": "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0",
-    "@khanacademy/eslint-plugin@^0.2.1": "https://registry.yarnpkg.com/@khanacademy/eslint-plugin/-/eslint-plugin-0.2.1.tgz#fc1d6ee0b34ab79a244c445fe4c40631e1974b48",
+    "@khanacademy/eslint-plugin@^0.2.2": "https://registry.yarnpkg.com/@khanacademy/eslint-plugin/-/eslint-plugin-0.2.2.tgz#c92ae153c3cd12ad2b887bfa3a520677233896eb",
     "acorn-jsx@^5.0.0": "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e",
     "acorn@^6.0.2": "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f",
     "ajv@^4.9.1": "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536",

--- a/node_modules/@khanacademy/eslint-plugin/README.md
+++ b/node_modules/@khanacademy/eslint-plugin/README.md
@@ -9,4 +9,5 @@ eslint plugin with our set of custom rules for various things
 - [khan/flow-array-type-style](docs/flow-array-type-style.md)
 - [khan/flow-no-one-tuple](docs/flow-no-one-tuple.md)
 - [khan/imports-requiring-flow](docs/imports-requiring-flow.md)
+- [khan/react-no-method-jsx-attribute](docs/react-no-method-jsx-attribute.md)
 - [khan/react-no-subscriptions-before-mount](docs/react-no-subscriptions-before-mount.md)

--- a/node_modules/@khanacademy/eslint-plugin/docs/react-no-method-jsx-attribute.md
+++ b/node_modules/@khanacademy/eslint-plugin/docs/react-no-method-jsx-attribute.md
@@ -1,0 +1,80 @@
+# Prevent passing methods as props to other components (react-no-method-jsx-attribute)
+
+Passing methods as props without pre-binding is a common mistake in React programming.  
+Components created using `createReactClass` avoid this issue because `createReactClass`
+pre-binds all non-lifecycle methods.
+
+This eslint rule warns against passing methods as props to other components and suggests
+using class properties instead.  This ensure that `this` is correct when the component 
+receiving the props calls it.
+
+## Rule Details
+
+The following are considered warnings:
+
+```js
+class Foo extends React.Component {
+    handleClick() {}
+    
+    render() {
+        return <div onClick={this.handleClick}>
+    }
+}
+```
+
+```js
+class Foo extends React.Component {
+    handleBaz() {}
+    
+    render() {
+        return <Bar onBaz={this.handleBaz}>
+    }
+}
+```
+
+The following are not considered warnings:
+
+```js
+class Foo extends React.Component {
+    handleClick = () => {}
+    
+    render() {
+        return <div onClick={this.handleClick}>
+    }
+}
+```
+
+```js
+class Foo extends React.Component {
+    handleClick() {}
+    
+    render() {
+        return <div onClick={() => this.handleClick()}>
+    }
+}
+```
+
+```js
+class Foo extends React.Component {
+    constructor(props) {
+        super(props);
+        this.handleClick = () => {};
+    }
+    
+    render() {
+        return <div onClick={this.handleClick}>
+    }
+}
+```
+
+```js
+class Foo extends React.Component {
+    get bar() {
+        return this._bar;
+    }
+
+    render() {
+        return <div id={this.bar} />
+    }
+}
+```

--- a/node_modules/@khanacademy/eslint-plugin/lib/index.js
+++ b/node_modules/@khanacademy/eslint-plugin/lib/index.js
@@ -3,6 +3,7 @@ module.exports = {
         "flow-array-type-style": require("./rules/flow-array-type-style.js"),
         "flow-no-one-tuple": require("./rules/flow-no-one-tuple.js"),
         "imports-requiring-flow": require("./rules/imports-requiring-flow.js"),
+        "react-no-method-jsx-attribute": require("./rules/react-no-method-jsx-attribute.js"),
         "react-no-subscriptions-before-mount": require("./rules/react-no-subscriptions-before-mount.js"),
     },
 };

--- a/node_modules/@khanacademy/eslint-plugin/lib/rules/react-no-method-jsx-attribute.js
+++ b/node_modules/@khanacademy/eslint-plugin/lib/rules/react-no-method-jsx-attribute.js
@@ -1,0 +1,73 @@
+module.exports = {
+    meta: {
+        docs: {
+            description: "Ensure that methods aren't used as jsx attributes",
+            category: "react",
+            recommended: false,
+        },
+        schema: [],
+    },
+
+    create(context) {
+        const methods = new Set();
+        const classProperties = new Set();
+
+        return {
+            ClassDeclaration(node) {
+                for (const child of node.body.body) {
+                    if (
+                        child.type === "ClassProperty" &&
+                        child.key.type === "Identifier"
+                    ) {
+                        classProperties.add(child.key.name);
+                    } else if (
+                        child.type === "MethodDefinition" &&
+                        child.kind === "method" &&
+                        child.key.type === "Identifier"
+                    ) {
+                        methods.add(child.key.name);
+                    }
+                }
+            },
+            "ClassDeclaration:exit"(node) {
+                for (const child of node.body.body) {
+                    if (
+                        child.type === "ClassProperty" &&
+                        child.key.type === "Identifier"
+                    ) {
+                        classProperties.delete(child.key.name);
+                    } else if (
+                        child.type === "MethodDefinition" &&
+                        child.kind === "method" &&
+                        child.key.type === "Identifier"
+                    ) {
+                        methods.delete(child.key.name);
+                    }
+                }
+            },
+            JSXAttribute(node) {
+                const {value} = node;
+                // value doesn't exist for boolean shorthand attributes
+                if (value && value.type === "JSXExpressionContainer") {
+                    const {expression} = node.value;
+                    if (expression.type === "MemberExpression") {
+                        const {object, property} = expression;
+                        if (
+                            object.type === "ThisExpression" &&
+                            property.type === "Identifier"
+                        ) {
+                            const {name} = property;
+                            if (methods.has(name)) {
+                                context.report({
+                                    node: node,
+                                    message:
+                                        "Methods cannot be passed as props, use a class property instead.",
+                                });
+                            }
+                        }
+                    }
+                }
+            },
+        };
+    },
+};

--- a/node_modules/@khanacademy/eslint-plugin/package.json
+++ b/node_modules/@khanacademy/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@khanacademy/eslint-plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publishConfig": {
     "access": "public"
   },

--- a/node_modules/@khanacademy/eslint-plugin/test/react-no-method-jsx-attribute_test.js
+++ b/node_modules/@khanacademy/eslint-plugin/test/react-no-method-jsx-attribute_test.js
@@ -1,0 +1,116 @@
+const path = require("path");
+
+const rule = require("../lib/index.js").rules["react-no-method-jsx-attribute"];
+const RuleTester = require("eslint").RuleTester;
+
+const parserOptions = {
+    parser: "babel-eslint",
+};
+
+const ruleTester = new RuleTester(parserOptions);
+
+ruleTester.run("react-no-method-jsx-attribute", rule, {
+    valid: [
+        // method arrow function in constructor
+        {
+            code: `
+class Foo {
+    constructor() {
+        this.handleClick = () => {};
+    }
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}`,
+            options: [],
+        },
+        // method arrow function class property
+        {
+            code: `
+class Foo {
+    handleClick = () => {}
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}`,
+            options: [],
+        },
+        // different classes using the same event handler
+        {
+            code: `
+class Foo {
+    handleClick = () => {}
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}
+
+class Bar {
+    handleClick() {}
+
+    render() {
+        return <div onClick={() => this.handleClick()} />
+    }
+}`,
+            options: [],
+        },
+        // getter method - called in Foo's scope so it's fine
+        {
+            code: `
+class Foo {
+    get bar() {
+        return this._bar;
+    }
+
+    render() {
+        return <div id={this.bar} />
+    }
+}`,
+            options: [],
+        },
+    ],
+    invalid: [
+        // regular method, not okay
+        {
+            code: `
+class Foo {
+    handleClick() {}
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}`,
+            options: [],
+            errors: [
+                "Methods cannot be passed as props, use a class property instead.",
+            ],
+        },
+        // two regular methods, both not okay, two errors
+        {
+            code: `
+class Foo {
+    handleClick() {}
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}
+
+class Bar {
+    handleClick() {}
+
+    render() {
+        return <div onClick={this.handleClick} />
+    }
+}`,
+            options: [],
+            errors: [
+                "Methods cannot be passed as props, use a class property instead.",
+                "Methods cannot be passed as props, use a class property instead.",
+            ],
+        },
+    ],
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "eslint-check": "eslint --print-config eslintrc | eslint-config-prettier-check"
   },
   "dependencies": {
-    "@khanacademy/eslint-plugin": "^0.2.1",
+    "@khanacademy/eslint-plugin": "^0.2.2",
     "babel-eslint": "10.0.1",
     "eslint": "5.8.0",
     "eslint-config-prettier": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,10 +90,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@khanacademy/eslint-plugin@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@khanacademy/eslint-plugin/-/eslint-plugin-0.2.1.tgz#fc1d6ee0b34ab79a244c445fe4c40631e1974b48"
-  integrity sha512-GO9M27Sor0QrOmnmdwORJtpgzwn8KiS908GI1Bw7hYfLe/PvbEb9iclLdDtObx9sx0WNj65OL1QuAgZo4+mO9g==
+"@khanacademy/eslint-plugin@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@khanacademy/eslint-plugin/-/eslint-plugin-0.2.2.tgz#c92ae153c3cd12ad2b887bfa3a520677233896eb"
+  integrity sha512-JmLTlbbx9lZAwElSaRiQerTyrIsH/im2GsY1+0m8gBVF1MZzNORMQU5Lw8cZUKyfIlyNOn/s5L8xoYD266TVMA==
 
 acorn-jsx@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
This new version has a new rule: react-no-method-jsx-attribute.

This rule prevents errors from passing methods that aren't prebound
as props (JSX attributes) to other components.

**Test Plan:**
- https://github.com/Khan/eslint-plugin-khan/pull/3 contains a suite of tests
- https://phabricator.khanacademy.org/D58910 updates webapp to fix all violations of this rule