### PR TITLE
Allows implementation of custom linters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,10 @@ module khan_linter
 go 1.12
 
 require github.com/golangci/golangci-lint v1.21.0
+
+// https://github.com/golangci/golangci-lint/pull/841
+replace github.com/golangci/golangci-lint => github.com/dbraley/golangci-lint v1.21.1-0.20191111174454-ba0c6ddd069d
+
+// https://github.com/golang/tools/pull/156
+// https://github.com/golang/tools/pull/160
+replace golang.org/x/tools => github.com/golangci/tools v0.0.0-20190915081525-6aa350649b1c

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dbraley/golangci-lint v1.21.1-0.20191111174454-ba0c6ddd069d h1:MLhaU0n18sZjeI5oh/sUu4S7OqefK4UhpbCCS6M3mow=
+github.com/dbraley/golangci-lint v1.21.1-0.20191111174454-ba0c6ddd069d/go.mod h1:phxpHK52q7SE+5KpPnti4oZTdFCEsn/tKN+nFvCKXfk=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
@@ -104,6 +106,8 @@ github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21 h1:leSNB7iYzLYSS
 github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21/go.mod h1:tf5+bzsHdTM0bsB7+8mt0GUMvjCgwLpTapNZHU8AajI=
 github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0 h1:HVfrLniijszjS1aiNg8JbBMO2+E1WIQ+j/gL4SQqGPg=
 github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0/go.mod h1:qOQCunEYvmd/TLamH+7LlVccLvUH5kZNhbCgTHoBbp4=
+github.com/golangci/tools v0.0.0-20190915081525-6aa350649b1c h1:JF7g2hV+1F/DwJ3CrSxOc9ZNVY6N8zYt5mB0Qve//fU=
+github.com/golangci/tools v0.0.0-20190915081525-6aa350649b1c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 h1:zwtduBRr5SSWhqsYNgcuWO2kFlpdOZbP0+yRjmvPGys=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg8RkN3rCIMLGE9CyYmU9pY2Jer6DgANEnZ/L/cQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=


### PR DESCRIPTION
Replaced golangci-lint via go mod with i473 fork
Also replaced tools with golangci fork

Issue: INFRA-3846

Test plan:
run ka-lint on webapp
add a custom linter and run ka-lint on webapp again