### PR TITLE
Filter out deleted paths from files_to_lint in the pre-push hook

### DIFF
--- a/githook.py
+++ b/githook.py
@@ -175,7 +175,8 @@ def pre_push_hook(_unused_arg_remote_name, _unused_arg_remote_location):
 
         # Parse files to lint: split at NUL characters, remove blank entries,
         # and remove duplicates.
-        files_to_lint = list({f for f in files_to_lint.split('\0') if f})
+        files_to_lint = list({f for f in files_to_lint.split('\0')
+                              if f and os.path.exists(f)})
 
         # Lint the files, if any. If there are any errors, print a helpful
         # message, and return a nonzero status code to abort the push.


### PR DESCRIPTION
## Summary:
I'm a little wary about changing this as I have never personally used it (I deleted all git hooks shortly after cloning webapp the first time),
but this feels like a minimally invasive change.

Issue: https://khanacademy.atlassian.net/browse/FEI-3574

## Test plan:
🤞