### PR TITLE
adding bitrise ymls to blocklist of linter

### DIFF
--- a/lint_blacklist.txt
+++ b/lint_blacklist.txt
@@ -32,3 +32,8 @@ contrib/
 # Other files
 main.py
 api/v1.py
+
+# Bitrise yml files in mobile repo contain unicode not supported by "narrow"
+# python. Hopefully we can remove this if python3 upgrade fixes the issue.
+bitrise.yml
+.bitrise/workflow_archives/**


### PR DESCRIPTION
## Summary:
Due to "narrow" build python not being able to support the unicode for some emojis used in our build process,I am adding the bitrise yml files to the linting blocklist until we do the python3 upgrade.

Issue: XXX-XXXX

## Test plan:
N/A, can write a unit test that shows the linter will skip the files?