### PR TITLE
Bump flake8 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@
 #   to the /vendor/* directory in with your change as well.
 
 # Required by python lint checking
-# This is flake8 3.5.0 with one more commit to support `paths` in `.flake8`.
-git+git://github.com/pycqa/flake8.git@dd1e9d1cb7e9a232946c06aca1564d48d4d6f65e
+flake8==3.9.2
 
 # Required for yaml lint checking
 pyyaml==3.12


### PR DESCRIPTION
## Summary:
The commit referenced for flake8 no longer exists, upgrade to the latest version supported by py2 and py3. Also fixes [this issue](https://github.com/PyCQA/pyflakes/issues/367) when running with python3.8

Issue: XXX-XXXX

## Test plan:
Run on local (m1 macbook with python3.8 and python2.7