### PR TITLE
[🔥AUDIT🔥] Replace reference to `arc lint` with `make fixc`.

### DIFF
--- a/githook.py
+++ b/githook.py
@@ -189,7 +189,7 @@ def pre_push_hook(_unused_arg_remote_name, _unused_arg_remote_location):
                     '\n--- %s lint errors. Push aborted. ---' % num_errors,
                     file=sys.stderr)
                 six.print_(
-                    'Running `arc lint` may help to autofix the errors.',
+                    'Running `make fixc` may help to autofix the errors.',
                     file=sys.stderr)
                 return 1
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
We haven't used `arc` for forever!  Let's try a command that's more
likely to be useful.  `make fixc` doesn't exist in every repo that
uses khan-linter, but it does in webapp, and that's a big one.

Issue: https://khanacademy.slack.com/archives/C02NMB1R5/p1693959624754879

## Test plan:
None