### PR TITLE
[🔥AUDIT🔥] Get rid of the `jobs` argbument to flake8.

### DIFF
--- a/linters.py
+++ b/linters.py
@@ -319,11 +319,7 @@ class Flake8(Linter):
         # don't want to override the default excludes for the parent
         # repo.  Instead, we filter out errors we want to ignore
         # in `_process_one_line`, above.
-        # We force flake8 to run in serial until process-leaking is
-        # fixed, e.g. when flake8 has merged
-        #    https://gitlab.com/pycqa/flake8/merge_requests/228
-        # TODO(csilvers): remove `jobs=1` after we update vendor/.
-        style_guide = flake8.api.legacy.get_style_guide(jobs='1')
+        style_guide = flake8.api.legacy.get_style_guide()
         style_guide.init_report(Reporter)
         style_guide.check_files(self._files_to_ignored_errors.keys())
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
This both resolves a TODO, and fixes a bug where the new version of
flake8 expects an argparse.flag object instead of a string, and thus
was failing to parse this.

Issue: none

## Test plan:
I ran this with success:
```
cd khan/internal-webserver && ka-lint gae_dashboard/initiatives.py
```