### PR TITLE
One more place we have to fix things up for python3.

### DIFF
--- a/linters.py
+++ b/linters.py
@@ -1241,7 +1241,8 @@ class GoLint(Linter):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
 
-        stdout, stderr = process.communicate(input='\0'.join(dirs))
+        stdout, stderr = process.communicate(
+            input='\0'.join(dirs).encode('utf-8'))
         stdout, stderr = stdout.decode('utf-8'), stderr.decode('utf-8')
 
         # golangci-lint seems to exit 123 on errors, even if you tell it not to


### PR DESCRIPTION
## Summary:
Nobody noticed because nobody is using the default ka-linter, I guess.
Except me.

Issue: none

## Test plan:
I ran `ka-lint formatter.go` in the Khan/stackdriver-gae-logrus-plugin
directory, and no longer got an error running subprocess.